### PR TITLE
Add support for API Key and Key ID #105

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -28,6 +28,16 @@
   "default": "",
   "required": true
   },
+  "keyId": {
+  "title": "Key ID",
+  "description": "API Key/ID available from the official Wyze Portal",
+  "type": "string"
+  },
+  "apiKey": {
+  "title": "API Key",
+  "description": "API Key/ID available from the official Wyze Portal",
+  "type": "string"
+  },
   "refreshInterval": {
   "title": "Refresh Interval",
   "description": "Specify the number of milliseconds to wait between updates, default is 60000 ms (60 seconds)",

--- a/src/WyzeSmartHome.js
+++ b/src/WyzeSmartHome.js
@@ -42,6 +42,8 @@ module.exports = class WyzeSmartHome {
     return new WyzeAPI({
       username: this.config.username,
       password: this.config.password,
+      keyId: this.config.keyId,
+      apiKey: this.config.apiKey,
       phoneId: this.config.phoneId,
       mfaCode: this.config.mfaCode
     }, this.log)

--- a/src/wyz-api/index.js
+++ b/src/wyz-api/index.js
@@ -119,8 +119,8 @@ module.exports = class WyzeAPI {
     return result
   }
 
-  _performLoginRequest (data = {}) {
-    const url = 'user/login'
+  _performLoginRequest(data = {}) {
+    let url = 'user/login'
 
     data = {
       email: this.username,
@@ -131,6 +131,11 @@ module.exports = class WyzeAPI {
     const config = {
       baseURL: this.authBaseUrl,
       headers: { 'x-api-key': this.authApiKey, 'User-Agent': this.userAgent }
+    }
+
+    if (this.apiKey && this.keyId) {
+      url = 'api/user/login'
+      config.headers = { 'apikey': this.apiKey, 'keyid': this.keyId, 'User-Agent': 'homebridge-wyze-smart-home' };
     }
 
     return this._performRequest(url, data, config)


### PR DESCRIPTION
This will switch the auth request to the `/api/user/login` endpoint if `keyId` and `apiKey` are configured.

This change is necessary to ensure compatibility with the upcoming changes outlined here: https://support.wyze.com/hc/en-us/articles/16129834216731