### PR TITLE
Update thermostat behavior and update fork branch to be in line with current WyzeAccessory updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ persist/
 package-lock.json
 config.json
 backups/
-accessories/.cachedAccessories.bak
 *.bak
-accessories/cachedAccessories
 testing/
 accessories/uiAccessoriesLayout.json
 bun.lockb
+accessories/*cachedAccessories*
+homebridge.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ accessories/.cachedAccessories.bak
 accessories/cachedAccessories
 testing/
 accessories/uiAccessoriesLayout.json
+bun.lockb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 ## Releases
 
+### v0.5.46
+- Update thermostat structure to new format
+- Update thermostat to have min/max thresholds closer to Wyze Thermostat thresholds -  https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/203
+- Update thermostat to avoid constant reboot -  https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/228
+
 ### v0.5.45
 - Increase Wyze-api Verison 1.0.7
 - Update Logging

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "lint": "eslint src/**.js --max-warnings=0",
     "start": "homebridge -I -P . -U ~/Work/homebridge-wyze-api"
-
   },
   "keywords": [
     "homebridge-plugin",
@@ -34,20 +33,19 @@
     "utf8": "^3.0.0",
     "uuid": "8.3.2",
     "uuid-by-string": "4.0.0",
-    "base64-js":  "1.5.1",
+    "base64-js": "1.5.1",
     "moment": "2.29.4",
     "urllib": "3.18.0",
     "querystring": "0.2.1",
     "inherits": "2.0.4",
     "wyze-api": "^1.1.1"
-    },
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.27.1",
     "@typescript-eslint/parser": "^5.27.1",
     "eslint": "^8.17.0",
     "eslint-config-standard": "^17.0.0",
     "homebridge": "1.6.1"
-
   },
   "funding": [
     {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "scripts": {
     "lint": "eslint src/**.js --max-warnings=0",
-    "start": "homebridge -I -P . -U . > homebrfidge.log"
+    "start": "homebridge -I -P . -U . > homebridge.log"
   },
   "keywords": [
     "homebridge-plugin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.39",
+  "version": "0.5.40",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.45",
+  "version": "0.5.46",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",
   "scripts": {
     "lint": "eslint src/**.js --max-warnings=0",
-    "start": "homebridge -I -P . -U ~/Work/homebridge-wyze-api"
+    "start": "homebridge -I -P . -U . > homebrfidge.log"
   },
   "keywords": [
     "homebridge-plugin",

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -26,60 +26,6 @@ module.exports = class WyzeAccessory {
     return this.homeKitAccessory.context.product_model;
   }
 
-  // from thermostat
-  get thermostatTemperature() {
-    return this.homeKitAccessory.context.device_params?.temperature;
-  }
-  set thermostatTemperature(value) {
-    this.homeKitAccessory.context.device_params.temperature = value;
-  }
-
-  get thermostatModeSys() {
-    return this.homeKitAccessory.context.device_params?.mode_sys;
-  }
-  set thermostatModeSys(value) {
-    this.homeKitAccessory.context.device_params.mode_sys = value;
-  }
-
-  get thermostatWorkingState() {
-    return this.homeKitAccessory.context.device_params?.working_state;
-  }
-  set thermostatWorkingState(value) {
-    this.homeKitAccessory.context.device_params.working_state = value;
-  }
-
-  get thermostatCoolSetpoint() {
-    return this.homeKitAccessory.context.device_params?.cool_sp;
-  }
-  set thermostatCoolSetpoint(value) {
-    this.homeKitAccessory.context.device_params.cool_sp = value;
-  }
-
-  get thermostatHeatSetpoint() {
-    return this.homeKitAccessory.context.device_params?.heat_sp;
-  }
-  set thermostatHeatSetpoint(value) {
-    this.homeKitAccessory.context.device_params.heat_sp = value;
-  }
-
-  get thermostatTempUnit() {
-    return this.homeKitAccessory.context.device_params?.temp_unit;
-  }
-  set thermostatTempUnit(value) {
-    this.homeKitAccessory.context.device_params.temp_unit = value;
-  }
-
-  get thermostatTime2Temp() {
-    return this.homeKitAccessory.context.device_params?.time2temp_val;
-  }
-  set thermostatTime2Temp(value) {
-    this.homeKitAccessory.context.device_params.time2temp_val = value;
-  }
-
-  get thermostatConnState() {
-    return this.homeKitAccessory.context.conn_state;
-  }
-
   /** Determines whether this accessory matches the given Wyze device */
   matches(device) {
     return this.mac === device.mac;
@@ -89,25 +35,6 @@ module.exports = class WyzeAccessory {
     const productType = device.product_type;
 
     switch (productType) {
-      case "Thermostat":
-        this.homeKitAccessory.context = {
-          mac: device.mac,
-          product_type: device.product_type,
-          product_model: device.product_model,
-          nickname: device.nickname,
-          conn_state: device.conn_state,
-          push_switch: device.push_switch,
-          device_params: (device.device_params = {
-            temperature: this.thermostatTemperature,
-            cool_sp: this.thermostatCoolSetpoint,
-            heat_sp: this.thermostatHeatSetpoint,
-            working_state: this.thermostatWorkingState,
-            temp_unit: this.thermostatTempUnit,
-            mode_sys: this.thermostatModeSys,
-            time2temp_val: this.thermostatTime2Temp,
-          }),
-        };
-        break;
       default:
         this.homeKitAccessory.context = {
           mac: device.mac,
@@ -150,121 +77,6 @@ module.exports = class WyzeAccessory {
 
   updateCharacteristics(device) {
     //
-  }
-
-  // Thermostat Methods
-  async thermostatGetIotProp() {
-    // Set Defaults
-    this.thermostatTemperature = 69.0;
-    this.thermostatCoolSetpoint = 65.0;
-    this.thermostatHeatSetpoint = 72.0;
-    this.thermostatModeSys = "auto";
-    this.thermostatWorkingState = "idle";
-    this.thermostatTempUnit = "F";
-
-    let response;
-    try {
-      this.updating = true;
-      response = await this.plugin.client.thermostatGetIotProp(this.mac);
-      let properties = response.data.props;
-      const prop_key = Object.keys(properties);
-      for (const element of prop_key) {
-        const prop = element;
-        switch (prop) {
-          case "temperature":
-            this.homeKitAccessory.context.device_params.temperature =
-              Math.round(properties[prop]);
-            continue;
-          case "cool_sp":
-            this.homeKitAccessory.context.device_params.cool_sp = Math.round(
-              properties[prop]
-            );
-            continue;
-          case "heat_sp":
-            this.homeKitAccessory.context.device_params.heat_sp = Math.round(
-              properties[prop]
-            );
-            continue;
-          case "working_state":
-            this.homeKitAccessory.context.device_params.working_state =
-              properties[prop];
-            continue;
-          case "temp_unit":
-            this.homeKitAccessory.context.device_params.temp_unit =
-              properties[prop];
-            continue;
-          case "mode_sys":
-            this.homeKitAccessory.context.device_params.mode_sys =
-              properties[prop];
-            continue;
-          case "iot_state":
-            this.homeKitAccessory.context.conn_state = properties[prop];
-            continue;
-          case "time2temp_val":
-            this.homeKitAccessory.context.device_params.thermostatTime2Temp =
-              properties[prop];
-            continue;
-        }
-      }
-      this.lastTimestamp = response.ts;
-    } catch (e) {
-      this.plugin.log.error("Error in thermostat: " + e);
-    } finally {
-      this.updating = false;
-      return response;
-    }
-  }
-
-  async setPreset(value) {
-    const response = await this.plugin.client.thermostatSetIotProp(
-      this.mac,
-      this.product_model,
-      "config_scenario",
-      value
-    );
-    return response;
-  }
-  // auto, on, off / / ['auto', 'circ', 'on']
-  async setFanMode(value) {
-    const response = await this.plugin.client.thermostatSetIotProp(
-      this.mac,
-      this.product_model,
-      "fan_mode",
-      value
-    );
-    return response;
-  }
-  // auto, heat, cool
-  async setHvacMode(value) {
-    const response = await this.plugin.client.thermostatSetIotProp(
-      this.mac,
-      this.product_model,
-      "mode_sys",
-      value
-    );
-    return response;
-  }
-
-  // heat stop point
-  async setHeatPoint(value) {
-    const response = await this.plugin.client.thermostatSetIotProp(
-      this.mac,
-      this.product_model,
-      "heat_sp",
-      value
-    );
-    return response;
-  }
-
-  // Cool stop point
-  async setCoolPoint(value) {
-    const response = await this.plugin.client.thermostatSetIotProp(
-      this.mac,
-      this.product_model,
-      "cool_sp",
-      value
-    );
-    return response;
   }
 
   sleep(ms) {

--- a/src/accessories/WyzeThermostat.js
+++ b/src/accessories/WyzeThermostat.js
@@ -338,7 +338,7 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
   // Helper Functions
 
   debugLog(message) {
-    if (this.plugin.config.logLevel == "debug")
+    if (this.plugin.config.logLevel == "debug" && this.plugin.config.pluginLoggingEnabled)
       this.plugin.log.info(
         this.colors.CYAN + "[Thermostat] " + message + this.colors.RESET
       );

--- a/src/accessories/WyzeThermostat.js
+++ b/src/accessories/WyzeThermostat.js
@@ -46,6 +46,9 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
       .onSet(this.handleCoolingThresholdTemperatureSet.bind(this))
 
     // Heating setpoint handlers - needed for system in Auto
+    // Default max value is 25, but we set it higher here for Wyze thermostats
+    // Shoutout to @fennix for the idea here: 
+    // https://github.com/tomas-kulhanek/homebridge-fenix-v24-wifi/blob/30a016ea125a5cfd439106472c1afd11f0ad6a2f/src/platformAccessory.ts#L65
     this.service
       .getCharacteristic(Characteristic.HeatingThresholdTemperature)
       .onGet(this.handleHeatingThresholdTemperatureGet.bind(this))


### PR DESCRIPTION
This PR should address four things:

1. Refactor of WyzeAccessory to remove thermostat relevant components that were left previously
2. Update WyzeThermostat to hold all needed functionality inside it's own class and not rely on WyzeAccessory - this is to fall in line with the new structure of the project
3. Push a fix to an issue where you cannot set the thermostat temp above or below the arbitrary thresholds imposed by Homekit - #203 
4. Fix for constant reboot when using thermostat - #228 