### PR TITLE
replaced undefined this.hexValue with defined hexValue

### DIFF
--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -227,7 +227,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
           await this.plugin.client.setMeshHue(
             this.mac,
             this.product_model,
-            this.hexValue
+            hexValue
           );
           this.cacheUpdated = false;
         } else {


### PR DESCRIPTION
As detailed in #234 and #247, replaced `this.hexValue` in WyzeMeshLight.js `setHue()` function with `hexValue`, as `this.hexValue` is not defined in the file. This paradigm matches `setSaturation()`, where the exact same `hexValue` logic exists.