### PR TITLE
Remove breaking sleep and state reporting for garage door

### DIFF
--- a/src/accessories/WyzeCamera.js
+++ b/src/accessories/WyzeCamera.js
@@ -498,7 +498,6 @@ module.exports = class WyzeCamera extends WyzeAccessory {
         `[Camera Garage Door] Setting Target State for ${this.mac} (${this.display_name}) to ${value}`
       );
     this.plugin.client.garageDoor(this.mac, this.product_model);
-    await this.sleep(1000);
     if (value == 0) {
       this.garageDoorService
         .getCharacteristic(Characteristic.CurrentDoorState)

--- a/src/accessories/WyzeCamera.js
+++ b/src/accessories/WyzeCamera.js
@@ -323,9 +323,6 @@ module.exports = class WyzeCamera extends WyzeAccessory {
                   );
                 }
                 this.garageDoor = property.value;
-                this.garageDoorService
-                  .getCharacteristic(Characteristic.CurrentDoorState)
-                  .updateValue(this.garageDoor);
               }
               break;
           }


### PR DESCRIPTION
Fix https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/193

Solution detailed by @alanhartless in https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/193#issuecomment-2023197534 to solve unreliable garage state status.

This has worked for me and i currently run on top of 0.5.46. Previously, states would constantly flip back and forth making the integration unusable.



