### PR TITLE
Check for "undefi" property values on update

### DIFF
--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -77,7 +77,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     if (
         property.value != null &&
         property.value !== "0" &&
-        property.value != "undefi"
+        property.value !== "undefi"
     ) {
       return true;
     } else {

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -60,16 +60,29 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       for (const property of propertyList.data.property_list) {
         switch (property.pid) {
           case WYZE_API_BRIGHTNESS_PROPERTY:
-            if (property.value != null) this.updateBrightness(property.value);
+            if (this.isValidProperty(property)) this.updateBrightness(property.value);
             break;
           case WYZE_API_COLOR_TEMP_PROPERTY:
-            if (property.value != null && property.value !== "0") this.updateColorTemp(property.value);
+            if (this.isValidProperty(property)) this.updateColorTemp(property.value);
             break;
           case WYZE_API_COLOR_PROPERTY:
-            if (property.value != null && property.value !== "0") this.updateColor(property.value);
+            if (this.isValidProperty(property)) this.updateColor(property.value);
             break;
         }
       }
+    }
+  }
+
+  isValidProperty(property) {
+    if (
+        property.value != null &&
+        property.value !== "0" &&
+        property.value != "undefi"
+    ) {
+      return true;
+    } else {
+      this.plugin.log(`Encountered invalid property value: ${JSON.stringify(property, null, 2)}`);
+      return false;
     }
   }
 


### PR DESCRIPTION
There was a bug where we try to pass the string "undefi" into the colorsys `hex2Hsv` method. The library does not handle this gracefully and it results in the error:

```
TypeError: Cannot read properties of null (reading 'r')
    at Object.colorsys.hex2Hsv (/var/lib/homebridge/node_modules/homebridge-wyze-smart-home/node_modules/colorsys/colorsys.js:197:31)
    at WyzeMeshLight.updateColor (/var/lib/homebridge/node_modules/homebridge-wyze-smart-home/src/accessories/WyzeMeshLight.js:104:31)
    at WyzeMeshLight.updateCharacteristics (/var/lib/homebridge/node_modules/homebridge-wyze-smart-home/src/accessories/WyzeMeshLight.js:69:46)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Here we add a check to the `updateCharacteristics` method (alongside two others that already existed) to ignore this invalid value rather than trying to act on it.

In my local testing the ability to set colors was not impacted as logging seems to indicate a valid color is later provided for the same device. The invalid string itself appears to originate from the WyzeAPI library.

See issues: https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/251 https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/232 https://github.com/jfarmer08/homebridge-wyze-smart-home/issues/228