### PR TITLE
Bump to 0.5.55: Fix restart loop, null guard API responses, unhandled…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.54",
+  "version": "0.5.55",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",
@@ -21,8 +21,8 @@
     "url": "http://github.com/jfarmer08/homebridge-wyze-smart-home/issues"
   },
   "engines": {
-    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
-    "node": "^18.20.4 || ^20.15.1 || ^22.0.0 || ^24"
+    "homebridge": "^1.6.0 || ^2.0.0",
+    "node": "^20.15.1 || ^22.0.0 || ^24.0.0"
   },
   "dependencies": {
     "aws-sdk": "2.1693.0",
@@ -42,7 +42,7 @@
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.0",
     "eslint-config-standard": "^17.1.0",
-    "homebridge": "^2.0.0-beta.0"
+    "homebridge": "^2.0.0"
   },
   "funding": [
     {

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -59,7 +59,7 @@ module.exports = class WyzeAccessory {
 
     this.lastDevice = device;
     if (this.shouldUpdateCharacteristics(timestamp)) {
-      this.updateCharacteristics(device);
+      Promise.resolve(this.updateCharacteristics(device)).catch(() => {});
     }
   }
   shouldUpdateCharacteristics(timestamp) {

--- a/src/accessories/WyzeCamera.js
+++ b/src/accessories/WyzeCamera.js
@@ -247,7 +247,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
           this.mac,
           this.product_model
         );
-        for (const property of propertyList.data.property_list) {
+        for (const property of propertyList?.data?.property_list ?? []) {
           switch (property.pid) {
             case "P1":
               if (

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -103,6 +103,8 @@ module.exports = class WyzeHMS extends WyzeAccessory {
         return Characteristic.SecuritySystemTargetState.AWAY_ARM;
       case "disarm":
         return Characteristic.SecuritySystemTargetState.DISARM;
+      default:
+        return Characteristic.SecuritySystemTargetState.DISARM;
     }
   }
   convertHomeKitStateToHmsState(homeKitState) {
@@ -122,7 +124,7 @@ module.exports = class WyzeHMS extends WyzeAccessory {
   async getHmsID() {
     if (this.hmsId == null || this.hmsId == "undefined") {
       const response = await this.plugin.client.getPlanBindingListByUser();
-      this.hmsId = response.data[0].deviceList[0].device_id;
+      this.hmsId = response?.data?.[0]?.deviceList?.[0]?.device_id;
       return this.hmsId;
     } else return this.hmsId;
   }

--- a/src/accessories/WyzeLight.js
+++ b/src/accessories/WyzeLight.js
@@ -49,7 +49,7 @@ module.exports = class WyzeLight extends WyzeAccessory {
         this.mac,
         this.product_model
       );
-      for (const property of propertyList.data.property_list) {
+      for (const property of propertyList?.data?.property_list ?? []) {
         switch (property.pid) {
           case WYZE_API_BRIGHTNESS_PROPERTY:
             this.updateBrightness(property.value);

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -107,7 +107,8 @@ module.exports = class WyzeLock extends WyzeAccessory {
         this.mac,
         this.product_model
       );
-      let lockProperties = propertyList.device;
+      let lockProperties = propertyList?.device;
+      if (!lockProperties) return false;
       const prop_key = Object.keys(lockProperties);
       for (const element of prop_key) {
         const prop = element;
@@ -138,7 +139,8 @@ module.exports = class WyzeLock extends WyzeAccessory {
             break;
         }
       }
-      let lockerStatusProperties = propertyList.device.locker_status;
+      let lockerStatusProperties = lockProperties.locker_status;
+      if (!lockerStatusProperties) return false;
       const prop_keyLock = Object.keys(lockerStatusProperties);
       for (const element of prop_keyLock) {
         const prop = element;

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -57,7 +57,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
         this.mac,
         this.product_model
       );
-      for (const property of propertyList.data.property_list) {
+      for (const property of propertyList?.data?.property_list ?? []) {
         switch (property.pid) {
           case WYZE_API_BRIGHTNESS_PROPERTY:
             if (this.isValidProperty(property)) this.updateBrightness(property.value);

--- a/src/accessories/WyzeThermostat.js
+++ b/src/accessories/WyzeThermostat.js
@@ -301,7 +301,9 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
     this.debugLog("Updating status of " + this.display_name);
 
     // have to wait for this call to finish before updating or we might get null data
-    this.thermostatGetIotProp().then(this.fillData.bind(this));
+    this.thermostatGetIotProp().then(this.fillData.bind(this)).catch(e => {
+      this.plugin.log.error("Error updating thermostat: " + e);
+    });
   }
 
   fillData() {


### PR DESCRIPTION
Fixes #295 — continuous Homebridge restart loop introduced in 0.5.54.

Two issues combined to cause the restart loop on Node 20+:

1. **Null API responses** — Several accessories called `Object.keys()` or iterated directly over API response data without guarding against null/ undefined. When the Wyze API returns an unexpected or incomplete response (network blip, auth timeout, brief outage), this threw a TypeError.

2. **Unhandled promise rejections** — `updateCharacteristics()` was called fire-and-forget with no `.catch()`. In Node.js 15+, unhandled rejections terminate the process. Combined with (1), any transient API hiccup would crash Homebridge and trigger the restart loop.

- `WyzeLock.js` — guard `propertyList.device` and `locker_status` before calling Object.keys(); return false on missing data instead of crashing
- `WyzeLight.js` — guard `propertyList.data.property_list` with optional chaining + nullish coalescing fallback to empty array
- `WyzeMeshLight.js` — same fix as WyzeLight
- `WyzeCamera.js` — same fix as WyzeLight
- `WyzeHMS.js` — guard deep chain `response.data[0].deviceList[0].device_id` with optional chaining; add default DISARM return to convertHmsStateToHomeKitState so unknown states never return undefined

- `WyzeAccessory.js` — wrap `updateCharacteristics()` call in `Promise.resolve(...).catch()` so any async throw is caught rather than becoming a fatal unhandled rejection
- `WyzeThermostat.js` — add `.catch()` to the `thermostatGetIotProp().then(fillData)` chain

- `package.json` — update `engines.homebridge` from `^2.0.0-beta.0` to `^2.0.0` now that Homebridge 2.0.2 stable is released
- `package.json` — update `devDependencies.homebridge` same way

**This release requires Node.js 20 or later.**

Node.js 18 reached end-of-life in April 2025 and was dropped in 0.5.54. Homebridge 1.x users still on Node 18 should upgrade to Node 20 LTS before installing this version. The official Homebridge Docker image already ships Node 24. Supported versions: Node 20, 22, 24.