### PR TITLE
v0.5.56: Stability hardening, null safety, and Homebridge 1.x/2.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ accessories/uiAccessoriesLayout.json
 bun.lockb
 accessories/*cachedAccessories*
 homebridge.log
+/.claude

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.55",
+  "version": "0.5.56",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",
@@ -22,7 +22,7 @@
   },
   "engines": {
     "homebridge": "^1.6.0 || ^2.0.0",
-    "node": "^20.15.1 || ^22.0.0 || ^24.0.0"
+    "node": "^18.17.0 || ^20.15.1 || ^22.0.0 || ^24.0.0"
   },
   "dependencies": {
     "aws-sdk": "2.1693.0",
@@ -35,7 +35,7 @@
     "urllib": "3.18.0",
     "utf8": "^3.0.0",
     "uuid-by-string": "4.0.0",
-    "wyze-api": "1.1.12"
+    "wyze-api": "^1.1.12"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "base64-js": "1.5.1",
     "colorsys": "^1.0.22",
     "crypto-js": "4.2.0",
-    "homebridge-config-ui-x": "^4.56.4",
     "querystring": "0.2.1",
     "urllib": "3.18.0",
     "utf8": "^3.0.0",

--- a/src/WyzeSmartHome.js
+++ b/src/WyzeSmartHome.js
@@ -41,6 +41,7 @@ module.exports = class WyzeSmartHome {
 
     this.accessories = []
     this._fastPollStats = new Map()
+    this._knownUnsupported = new Set()
 
     this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this))
   }
@@ -142,24 +143,23 @@ module.exports = class WyzeSmartHome {
   }
 
   async refreshDevices() {
-    if (this.config.pluginLoggingEnabled) {
-      if (this._fastPollStats.size > 0) {
-        for (const [, stats] of this._fastPollStats) {
-          const sinceStr = stats.since.toLocaleTimeString()
-          this.log(`[LockFastPoll] ${stats.name}: ${stats.successes}/${stats.attempts} polls since ${sinceStr}`)
-        }
+    let fastPollSummary = ''
+    if (this._fastPollStats.size > 0) {
+      const parts = []
+      for (const [, stats] of this._fastPollStats) {
+        parts.push(`${stats.name}: ${stats.successes}/${stats.attempts} fast polls`)
       }
-      this._fastPollStats = new Map()
+      fastPollSummary = ` (${parts.join(', ')})`
     }
-    if (this.config.pluginLoggingEnabled) this.log('Refreshing devices...')
+    this._fastPollStats = new Map()
 
     try {
       const objectList = await this.client.getObjectList()
       const timestamp = objectList.ts
       const devices = objectList.data.device_list
 
-      if (this.config.pluginLoggingEnabled) this.log(`Found ${devices.length} device(s)`)
       await this.loadDevices(devices, timestamp)
+      if (this.config.pluginLoggingEnabled) this.log(`Refreshed ${this.accessories.length}/${devices.length} devices${fastPollSummary}`)
     } catch (e) {
       this.log.error(`Error getting devices: ${e}`)
       throw e
@@ -189,7 +189,10 @@ module.exports = class WyzeSmartHome {
   async loadDevice(device, timestamp) {
     const accessoryClass = this.getAccessoryClass(device.product_type, device.product_model, device.mac, device.nickname)
     if (!accessoryClass) {
-      if (this.config.pluginLoggingEnabled) this.log(`[${device.product_type}] Unsupported device type: (Name: ${device.nickname}) (MAC: ${device.mac}) (Model: ${device.product_model})`)
+      if (this.config.pluginLoggingEnabled && !this._knownUnsupported.has(device.mac)) {
+        this._knownUnsupported.add(device.mac)
+        this.log(`[${device.product_type}] Unsupported device type: (Name: ${device.nickname}) (MAC: ${device.mac}) (Model: ${device.product_model})`)
+      }
       return
     }
     else if (this.config.filterByMacAddressList?.find(d => d === device.mac) || this.config.filterDeviceTypeList?.find(d => d === device.product_type)) {
@@ -207,8 +210,6 @@ module.exports = class WyzeSmartHome {
       const homeKitAccessory = this.createHomeKitAccessory(device)
       accessory = new accessoryClass(this, homeKitAccessory)
       this.accessories.push(accessory)
-    } else {
-      if (this.config.pluginLoggingEnabled) this.log(`[${device.product_type}] Loading accessory from cache ${device.nickname} (MAC: ${device.mac})`)
     }
     accessory.update(device, timestamp)
 
@@ -218,34 +219,35 @@ module.exports = class WyzeSmartHome {
   getAccessoryClass(type, model) {
     switch (type) {
       case 'OutdoorPlug':
-        if (Object.values(OutdoorPlugModels).includes(model)) { return WyzePlug }
+        return Object.values(OutdoorPlugModels).includes(model) ? WyzePlug : null
       case 'Plug':
-        if (Object.values(PlugModels).includes(model)) { return WyzePlug }
+        return Object.values(PlugModels).includes(model) ? WyzePlug : null
       case 'Light':
-        if (Object.values(LightModels).includes(model)) { return WyzeLight }
+        return Object.values(LightModels).includes(model) ? WyzeLight : null
       case 'MeshLight':
-        if (Object.values(MeshLightModels).includes(model)) { return WyzeMeshLight }
+        return Object.values(MeshLightModels).includes(model) ? WyzeMeshLight : null
       case 'LightStrip':
-        if (Object.values(LightStripModels).includes(model)) { return WyzeMeshLight }
+        return Object.values(LightStripModels).includes(model) ? WyzeMeshLight : null
       case 'ContactSensor':
-        if (Object.values(ContactSensorModels).includes(model)) { return WyzeContactSensor }
+        return Object.values(ContactSensorModels).includes(model) ? WyzeContactSensor : null
       case 'MotionSensor':
-        if (Object.values(MotionSensorModels).includes(model)) { return WyzeMotionSensor }
+        return Object.values(MotionSensorModels).includes(model) ? WyzeMotionSensor : null
       case 'Lock':
-        if (Object.values(LockModels).includes(model)) { return WyzeLock }
+        return Object.values(LockModels).includes(model) ? WyzeLock : null
       case 'TemperatureHumidity':
-        if (Object.values(TemperatureHumidityModels).includes(model)) { return WyzeTemperatureHumidity }
+        return Object.values(TemperatureHumidityModels).includes(model) ? WyzeTemperatureHumidity : null
       case 'LeakSensor':
-        if (Object.values(LeakSensorModels).includes(model)) { return WyzeLeakSensor }
+        return Object.values(LeakSensorModels).includes(model) ? WyzeLeakSensor : null
       case 'Camera':
-        if (Object.values(CameraModels).includes(model)) { return WyzeCamera }
+        return Object.values(CameraModels).includes(model) ? WyzeCamera : null
       case 'Common':
-        if (Object.values(LockBoltV2Models).includes(model)) { return WyzeLockBoltV2 }
-        if (Object.values(CommonModels).includes(model)) { return WyzeSwitch }
+        if (Object.values(LockBoltV2Models).includes(model)) return WyzeLockBoltV2
+        if (Object.values(CommonModels).includes(model)) return WyzeSwitch
+        return null
       case 'S1Gateway':
-        if (Object.values(S1GatewayModels).includes(model)) { return WyzeHMS }
+        return Object.values(S1GatewayModels).includes(model) ? WyzeHMS : null
       case 'Thermostat':
-        if (Object.values(ThermostatModels).includes(model)) { return WyzeThermostat }
+        return Object.values(ThermostatModels).includes(model) ? WyzeThermostat : null
     }
   }
 

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -59,7 +59,24 @@ module.exports = class WyzeAccessory {
 
     this.lastDevice = device;
     if (this.shouldUpdateCharacteristics(timestamp)) {
-      Promise.resolve(this.updateCharacteristics(device)).catch(() => {});
+      this.lastTimestamp = timestamp;
+      this.updating = true;
+      try {
+        // Promise.resolve wraps both sync-return and async-return uniformly.
+        // The outer try/catch is required: if updateCharacteristics() throws
+        // synchronously, the throw escapes Promise.resolve() before .catch()
+        // is attached, which would turn update() into an unhandled rejection.
+        Promise.resolve(this.updateCharacteristics(device))
+          .catch(e => {
+            if (this.plugin?.log?.error)
+              this.plugin.log.error(`[${this.product_type}] Error updating "${this.display_name}": ${e}`);
+          })
+          .finally(() => { this.updating = false; });
+      } catch (e) {
+        this.updating = false;
+        if (this.plugin?.log?.error)
+          this.plugin.log.error(`[${this.product_type}] Error updating "${this.display_name}": ${e}`);
+      }
     }
   }
   shouldUpdateCharacteristics(timestamp) {

--- a/src/accessories/WyzeCamera.js
+++ b/src/accessories/WyzeCamera.js
@@ -186,10 +186,12 @@ module.exports = class WyzeCamera extends WyzeAccessory {
   }
 
   async updateCharacteristics(device) {
+    const wasOffline = this._lastConnState === 0;
+    this._lastConnState = device.conn_state;
     if (device.conn_state === 0) {
-      if (this.plugin.config.pluginLoggingEnabled)
+      if (!wasOffline && this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[Camera] Updating status ${this.mac} (${this.display_name}) to noResponse`
+          `[Camera] Updating status "${this.display_name} (${this.mac}) to noResponse"`
         );
       this.privacySwitch
         .getCharacteristic(Characteristic.On)
@@ -255,9 +257,9 @@ module.exports = class WyzeCamera extends WyzeAccessory {
                   (d) => d === this.mac
                 )
               ) {
-                if (this.plugin.config.pluginLoggingEnabled) {
+                  if (this.notification !== property.value && this.plugin.config.pluginLoggingEnabled) {
                   this.plugin.log(
-                    `[Camera] [Notification] Updating status of ${this.mac} (${this.display_name})`
+                    `[Camera] [Notification] Updating status of "${this.display_name} (${this.mac})"`
                   );
                 }
                 this.notification = property.value;
@@ -267,9 +269,9 @@ module.exports = class WyzeCamera extends WyzeAccessory {
               }
               break;
             case "P3":
-              if (this.plugin.config.pluginLoggingEnabled)
+              if (this.on !== property.value && this.plugin.config.pluginLoggingEnabled)
                 this.plugin.log(
-                  `[Camera] [Privacy] Updating status of ${this.mac} (${this.display_name})`
+                  `[Camera] [Privacy] Updating status of "${this.display_name} (${this.mac})"`
                 );
               this.on = property.value;
               this.privacySwitch
@@ -328,14 +330,17 @@ module.exports = class WyzeCamera extends WyzeAccessory {
           }
         }
       } else {
-        if (this.plugin.config.pluginLoggingEnabled)
-          this.plugin.log(
-            `[Camera] [Privacy] Updating status of ${this.mac} (${this.display_name})`
-          );
-        this.power_switch = device.device_params.power_switch;
-        this.privacySwitch
-          .getCharacteristic(Characteristic.On)
-          .updateValue(device.device_params.power_switch);
+        const newPowerSwitch = device.device_params?.power_switch;
+        if (newPowerSwitch != null) {
+          if (this.power_switch !== newPowerSwitch && this.plugin.config.pluginLoggingEnabled)
+            this.plugin.log(
+              `[Camera] [Privacy] Updating status of "${this.display_name} (${this.mac})"`
+            );
+          this.power_switch = newPowerSwitch;
+          this.privacySwitch
+            .getCharacteristic(Characteristic.On)
+            .updateValue(newPowerSwitch);
+        }
       }
     }
   }
@@ -513,7 +518,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
     return !!(
       this.plugin.config.garageDoorAccessory?.find((d) => d === this.mac) ||
       this.plugin.config.spotLightAccessory?.find((d) => d === this.mac) ||
-      this.plugin.config.alarmAccessory?.find((d) => d === this.mac) ||
+      this.plugin.config.sirenAccessory?.find((d) => d === this.mac) ||
       this.plugin.config.floodLightAccessory?.find((d) => d === this.mac) ||
       this.plugin.config.notificationAccessory?.find((d) => d === this.mac)
     );

--- a/src/accessories/WyzeCamera.js
+++ b/src/accessories/WyzeCamera.js
@@ -191,7 +191,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (!wasOffline && this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[Camera] Updating status "${this.display_name} (${this.mac}) to noResponse"`
+          `[Camera] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.privacySwitch
         .getCharacteristic(Characteristic.On)
@@ -257,7 +257,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
                   (d) => d === this.mac
                 )
               ) {
-                  if (this.notification !== property.value && this.plugin.config.pluginLoggingEnabled) {
+                if (this.notification !== property.value && this.plugin.config.pluginLoggingEnabled) {
                   this.plugin.log(
                     `[Camera] [Notification] Updating status of "${this.display_name} (${this.mac})"`
                   );

--- a/src/accessories/WyzeCamera.js
+++ b/src/accessories/WyzeCamera.js
@@ -199,7 +199,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
       if (this.plugin.config.sirenAccessory?.find((d) => d === device.mac)) {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[Camera] [Siren] Updating status ${this.mac} (${this.display_name}) to noResponse`
+            `[Camera] [Siren] Updating status of "${this.display_name} (${this.mac})" to noResponse`
           );
         this.sirenSwitch
           .getCharacteristic(Characteristic.On)
@@ -208,7 +208,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
       if (this.plugin.config.floodLightAccessory?.find((d) => d === this.mac)) {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[Camera] [FloodLight] Updating status of ${this.mac} (${this.display_name}) to noResponse`
+            `[Camera] [FloodLight] Updating status of "${this.display_name} (${this.mac})" to noResponse`
           );
         this.floodLightService
           .getCharacteristic(Characteristic.On)
@@ -217,7 +217,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
       if (this.plugin.config.spotLightAccessory?.find((d) => d === this.mac)) {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[Camera] [SpotLight] Updating status of ${this.mac} (${this.display_name}) to noResponse`
+            `[Camera] [SpotLight] Updating status of "${this.display_name} (${this.mac})" to noResponse`
           );
         this.spotLightService
           .getCharacteristic(Characteristic.On)
@@ -226,7 +226,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
       if (this.plugin.config.garageDoorAccessory?.find((d) => d === this.mac)) {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[Camera] [Garage Door] Updating status of ${this.mac} (${this.display_name}) to noResponse`
+            `[Camera] [Garage Door] Updating status of "${this.display_name} (${this.mac})" to noResponse`
           );
         this.garageDoorService
           .getCharacteristic(Characteristic.CurrentDoorState)
@@ -237,7 +237,7 @@ module.exports = class WyzeCamera extends WyzeAccessory {
       ) {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[Camera] [Notification] Updating status of ${this.mac} (${this.display_name}) to noResponse`
+            `[Camera] [Notification] Updating status of "${this.display_name} (${this.mac})" to noResponse`
           );
         this.notificationSwitch
           .getCharacteristic(Characteristic.On)

--- a/src/accessories/WyzeContactSensor.js
+++ b/src/accessories/WyzeContactSensor.js
@@ -102,7 +102,7 @@ module.exports = class WyzeContactSensor extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[ContactSensor] Updating status "${this.display_name} (${this.mac}) to noResponse"`
+          `[ContactSensor] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.getOnCharacteristic().updateValue(noResponse);
     } else {

--- a/src/accessories/WyzeContactSensor.js
+++ b/src/accessories/WyzeContactSensor.js
@@ -106,6 +106,7 @@ module.exports = class WyzeContactSensor extends WyzeAccessory {
         );
       this.getOnCharacteristic().updateValue(noResponse);
     } else {
+      if (!device.device_params) return;
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
           `[ContactSensor] Updating status of ${this.mac} (${this.display_name})`

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -125,6 +125,7 @@ module.exports = class WyzeHMS extends WyzeAccessory {
     if (this.hmsId == null || this.hmsId == "undefined") {
       const response = await this.plugin.client.getPlanBindingListByUser();
       this.hmsId = response?.data?.[0]?.deviceList?.[0]?.device_id;
+      if (!this.hmsId) throw new Error(`[HMS] Could not resolve HMS device ID for "${this.display_name}"`);
       return this.hmsId;
     } else return this.hmsId;
   }

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -41,7 +41,7 @@ module.exports = class WyzeHMS extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[HMS] Updating status ${this.mac} (${this.display_name}) to noResponse`
+          `[HMS] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.securityService.getCharacteristic(Characteristic.SecuritySystemCurrentState).updateValue(noResponse);
     } else {

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -87,6 +87,7 @@ module.exports = class WyzeHMS extends WyzeAccessory {
           this.display_name
         }" : "${this.convertHomeKitStateToHmsState(value)}"`
       );
+    await this.getHmsID();
     await this.plugin.client.setHMSState(
       this.hmsId,
       this.convertHomeKitStateToHmsState(value)

--- a/src/accessories/WyzeLeakSensor.js
+++ b/src/accessories/WyzeLeakSensor.js
@@ -107,6 +107,7 @@ module.exports = class WyzeHumidity extends WyzeAccessory {
         );
       this.getOnCharacteristic().updateValue(noResponse);
     } else {
+      if (!device.device_params) return;
       if (this.plugin.config.pluginLoggingEnabled) {
         this.plugin.log(
           `[LeakSensor] Updating status of ${this.mac} (${this.display_name})`

--- a/src/accessories/WyzeLeakSensor.js
+++ b/src/accessories/WyzeLeakSensor.js
@@ -103,7 +103,7 @@ module.exports = class WyzeHumidity extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[LeakSensor] Updating status ${this.mac} (${this.display_name}) to noResponse`
+          `[LeakSensor] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.getOnCharacteristic().updateValue(noResponse);
     } else {

--- a/src/accessories/WyzeLight.js
+++ b/src/accessories/WyzeLight.js
@@ -34,7 +34,7 @@ module.exports = class WyzeLight extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[Light] Updating status ${this.mac} (${this.display_name}) to noResponse`
+          `[Light] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.getCharacteristic(Characteristic.On).updateValue(noResponse);
     } else {

--- a/src/accessories/WyzeLight.js
+++ b/src/accessories/WyzeLight.js
@@ -17,15 +17,17 @@ module.exports = class WyzeLight extends WyzeAccessory {
   constructor(plugin, homeKitAccessory) {
     super(plugin, homeKitAccessory);
 
-    this.getCharacteristic(Characteristic.On).on("set", this.setOn.bind(this));
-    this.getCharacteristic(Characteristic.Brightness).on(
-      "set",
-      this.setBrightness.bind(this)
-    );
-    this.getCharacteristic(Characteristic.ColorTemperature).on(
-      "set",
-      this.setColorTemperature.bind(this)
-    );
+    this.getCharacteristic(Characteristic.On)
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
+    this.getCharacteristic(Characteristic.Brightness)
+      .onSet(this.setBrightness.bind(this));
+    this.getCharacteristic(Characteristic.ColorTemperature)
+      .onSet(this.setColorTemperature.bind(this));
+  }
+
+  async getOn() {
+    return this._switchState ?? false;
   }
 
   async updateCharacteristics(device) {
@@ -41,9 +43,11 @@ module.exports = class WyzeLight extends WyzeAccessory {
           `[Light] Updating status of ${this.mac} (${this.display_name})`
         );
       }
-      this.getCharacteristic(Characteristic.On).updateValue(
-        device.device_params.switch_state
-      );
+      const switchState = device.device_params?.switch_state;
+      if (switchState != null) {
+        this._switchState = switchState;
+        this.getCharacteristic(Characteristic.On).updateValue(switchState);
+      }
 
       const propertyList = await this.plugin.client.getDevicePID(
         this.mac,
@@ -102,70 +106,31 @@ module.exports = class WyzeLight extends WyzeAccessory {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  async setOn(value, callback) {
+  async setOn(value) {
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[Light] Setting power for ${this.mac} (${this.display_name}) to ${value}`
       );
-
-    try {
-      await this.plugin.client.lightPower(
-        this.mac,
-        this.product_model,
-        value ? "1" : "0"
-      );
-      callback();
-    } catch (e) {
-      callback(e);
-    }
+    await this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0");
   }
 
-  async setBrightness(value, callback) {
+  async setBrightness(value) {
     await this.sleep(250);
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[Light] Setting brightness for ${this.mac} (${this.display_name}) to ${value}`
       );
-
-    try {
-      await this.plugin.client.setBrightness(
-        this.mac,
-        this.product_model,
-        value
-      );
-      callback();
-    } catch (e) {
-      callback(e);
-    }
+    await this.plugin.client.setBrightness(this.mac, this.product_model, value);
   }
 
-  // TODO: Issues when Color Temp higher then
-  async setColorTemperature(value, callback) {
+  async setColorTemperature(value) {
     await this.sleep(500);
-    const floatValue = this.plugin.client.rangeToFloat(
-      value,
-      HOMEKIT_COLOR_TEMP_MIN,
-      HOMEKIT_COLOR_TEMP_MAX
-    );
-    const wyzeValue = this.plugin.client.floatToRange(
-      floatValue,
-      WYZE_COLOR_TEMP_MIN,
-      WYZE_COLOR_TEMP_MAX
-    );
+    const floatValue = this.plugin.client.rangeToFloat(value, HOMEKIT_COLOR_TEMP_MIN, HOMEKIT_COLOR_TEMP_MAX);
+    const wyzeValue = this.plugin.client.floatToRange(floatValue, WYZE_COLOR_TEMP_MIN, WYZE_COLOR_TEMP_MAX);
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[Light] Setting color temperature for ${this.mac} (${this.display_name}) to ${value} (${wyzeValue})`
       );
-
-    try {
-      await this.plugin.client.setColorTemperature(
-        this.mac,
-        this.product_model,
-        wyzeValue
-      );
-      callback();
-    } catch (e) {
-      callback(e);
-    }
+    await this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue);
   }
 };

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -88,7 +88,7 @@ module.exports = class WyzeLock extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[Lock] Updating status "${this.display_name} (${this.mac}) to noResponse"`
+          `[Lock] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.lockService
         .getCharacteristic(Characteristic.LockCurrentState)

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -105,10 +105,10 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
       // Palm Lock (DX_PVLOC) intentionally uses lockBoltV2GetProperties — it supports all 6 props
       // and palmLockGetProperties in wyze-api is missing door-status + power-source.
       const result = await this.plugin.client.lockBoltV2GetProperties(this.mac, this.product_model);
-      if (result.code !== "1") {
+      if (!result || result.code !== "1") {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[LockBoltV2] IoT3 error for "${this.display_name} (${this.mac})": ${result.msg}`
+            `[LockBoltV2] IoT3 error for "${this.display_name} (${this.mac})": ${result?.msg ?? 'no response'}`
           );
         return false;
       }

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -88,7 +88,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     if (device.conn_state === 0) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[LockBoltV2] Updating status "${this.display_name} (${this.mac}) to noResponse"`
+          `[LockBoltV2] Updating status of "${this.display_name} (${this.mac})" to noResponse`
         );
       this.lockService
         .getCharacteristic(Characteristic.LockCurrentState)
@@ -262,10 +262,10 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
       const result = targetState === Characteristic.LockTargetState.SECURED
         ? await this.plugin.client.lockBoltV2Lock(this.mac, this.product_model)
         : await this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
-      if (result.code !== "1") {
+      if (!result || result.code !== "1") {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
-            `[LockBoltV2] Command failed for "${this.display_name} (${this.mac})": ${result.msg}`
+            `[LockBoltV2] Command failed for "${this.display_name} (${this.mac})": ${result?.msg ?? 'no response'}`
           );
         return;
       }

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -20,23 +20,13 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
   constructor(plugin, homeKitAccessory) {
     super(plugin, homeKitAccessory);
 
-    this.getCharacteristic(Characteristic.On).on("set", this.setOn.bind(this));
-    this.getCharacteristic(Characteristic.Brightness).on(
-      "set",
-      this.setBrightness.bind(this)
-    );
-    this.getCharacteristic(Characteristic.ColorTemperature).on(
-      "set",
-      this.setColorTemperature.bind(this)
-    );
-    this.getCharacteristic(Characteristic.Hue).on(
-      "set",
-      this.setHue.bind(this)
-    );
-    this.getCharacteristic(Characteristic.Saturation).on(
-      "set",
-      this.setSaturation.bind(this)
-    );
+    this.getCharacteristic(Characteristic.On)
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
+    this.getCharacteristic(Characteristic.Brightness).onSet(this.setBrightness.bind(this));
+    this.getCharacteristic(Characteristic.ColorTemperature).onSet(this.setColorTemperature.bind(this));
+    this.getCharacteristic(Characteristic.Hue).onSet(this.setHue.bind(this));
+    this.getCharacteristic(Characteristic.Saturation).onSet(this.setSaturation.bind(this));
 
     // Local caching of HSV color space handling separate Hue & Saturation on HomeKit
     // Caching idea for handling HSV colors from:
@@ -49,9 +39,11 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     if (device.conn_state == 0) {
       this.getCharacteristic(Characteristic.On).updateValue(noResponse);
     } else {
-      this.getCharacteristic(Characteristic.On).updateValue(
-        device.device_params.switch_state
-      );
+      const switchState = device.device_params?.switch_state;
+      if (switchState != null) {
+        this._switchState = switchState;
+        this.getCharacteristic(Characteristic.On).updateValue(switchState);
+      }
 
       const propertyList = await this.plugin.client.getDevicePID(
         this.mac,
@@ -77,7 +69,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     if (
         property.value != null &&
         property.value !== "0" &&
-        property.value !== "undefi"
+        property.value !== "undefined"
     ) {
       return true;
     } else {
@@ -153,139 +145,73 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     return this.getService().getCharacteristic(characteristic);
   }
 
-  async setOn(value, callback) {
+  async getOn() {
+    return this._switchState ?? false;
+  }
+
+  async setOn(value) {
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[MeshLight] Setting power for "${this.display_name} (${this.mac})" to ${value}"`
       );
-
-    try {
-      await this.plugin.client.lightMeshPower(
-        this.mac,
-        this.product_model,
-        value ? "1" : "0"
-      );
-      callback();
-    } catch (e) {
-      callback(e);
-    }
+    await this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0");
   }
 
-  async setBrightness(value, callback) {
+  async setBrightness(value) {
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[MeshLight] Setting brightness for "${this.display_name} (${this.mac}) to ${value}"`
       );
+    await this.plugin.client.setMeshBrightness(this.mac, this.product_model, value);
+  }
 
-    try {
-      await this.plugin.client.setMeshBrightness(
-        this.mac,
-        this.product_model,
-        value
+  async setColorTemperature(value) {
+    if (value == null) return;
+    const floatValue = this.plugin.client.rangeToFloat(value, HOMEKIT_COLOR_TEMP_MIN, HOMEKIT_COLOR_TEMP_MAX);
+    const wyzeValue = this.plugin.client.floatToRange(floatValue, WYZE_COLOR_TEMP_MIN, WYZE_COLOR_TEMP_MAX);
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(
+        `[MeshLight] Setting color temperature for "${this.display_name} (${this.mac}) to ${value} : ${wyzeValue}"`
       );
-      callback();
-    } catch (e) {
-      callback(e);
+    await this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue);
+  }
+
+  async setHue(value) {
+    if (value == null) return;
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(
+        `[MeshLight] Setting hue (color) for "${this.display_name} (${this.mac}) to ${value} : (H)S Values: ${value}, ${this.cache.saturation}"`
+      );
+    this.cache.hue = value;
+    if (this.cacheUpdated) {
+      let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
+      hexValue = hexValue.replace("#", "");
+      if (this.plugin.config.pluginLoggingEnabled) this.plugin.log(hexValue);
+      await this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue);
+      this.cacheUpdated = false;
+    } else {
+      this.cacheUpdated = true;
     }
   }
 
-  async setColorTemperature(value, callback) {
-    if (value != null) {
-      let floatValue = this.plugin.client.rangeToFloat(
-        value,
-        HOMEKIT_COLOR_TEMP_MIN,
-        HOMEKIT_COLOR_TEMP_MAX
+  async setSaturation(value) {
+    if (value == null) return;
+    if (this.plugin.config.pluginLoggingEnabled) {
+      this.plugin.log(
+        `[MeshLight] Setting saturation (color) for "${this.display_name} (${this.mac}) to ${value}"`
       );
-      let wyzeValue = this.plugin.client.floatToRange(
-        floatValue,
-        WYZE_COLOR_TEMP_MIN,
-        WYZE_COLOR_TEMP_MAX
+      this.plugin.log(
+        `[MeshLight] H(S) Values: ${this.cache.saturation}, ${value}`
       );
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(
-          `[MeshLight] Setting color temperature for "${this.display_name} (${this.mac}) to ${value} : ${wyzeValue}"`
-        );
-
-      try {
-        await this.plugin.client.setMeshColorTemperature(
-          this.mac,
-          this.product_model,
-          wyzeValue
-        );
-        callback();
-      } catch (e) {
-        callback(e);
-      }
     }
-  }
-
-  async setHue(value, callback) {
-    if (value != null) {
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(
-          `[MeshLight] Setting hue (color) for "${this.display_name} (${this.mac}) to ${value} : (H)S Values: ${value}, ${this.cache.saturation}"`
-        );
-
-      try {
-        this.cache.hue = value;
-        if (this.cacheUpdated) {
-          let hexValue = colorsys.hsv2Hex(
-            this.cache.hue,
-            this.cache.saturation,
-            100
-          );
-          hexValue = hexValue.replace("#", "");
-          if (this.plugin.config.pluginLoggingEnabled)
-            this.plugin.log(hexValue);
-          await this.plugin.client.setMeshHue(
-            this.mac,
-            this.product_model,
-            hexValue
-          );
-          this.cacheUpdated = false;
-        } else {
-          this.cacheUpdated = true;
-        }
-        callback();
-      } catch (e) {
-        callback(e);
-      }
-    }
-  }
-
-  async setSaturation(value, callback) {
-    if (value != null) {
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(
-          `[MeshLight] Setting saturation (color) for "${this.display_name} (${this.mac}) to ${value}"`
-        );
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(
-          `[MeshLight] H(S) Values: ${this.cache.saturation}, ${value}`
-        );
-
-      try {
-        this.cache.saturation = value;
-        if (this.cacheUpdated) {
-          let hexValue = colorsys.hsv2Hex(
-            this.cache.hue,
-            this.cache.saturation,
-            100
-          );
-          hexValue = hexValue.replace("#", "");
-          await this.plugin.client.setMeshSaturation(
-            this.mac,
-            this.product_model,
-            hexValue
-          );
-          this.cacheUpdated = false;
-        } else {
-          this.cacheUpdated = true;
-        }
-        callback();
-      } catch (e) {
-        callback(e);
-      }
+    this.cache.saturation = value;
+    if (this.cacheUpdated) {
+      let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
+      hexValue = hexValue.replace("#", "");
+      await this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue);
+      this.cacheUpdated = false;
+    } else {
+      this.cacheUpdated = true;
     }
   }
 };

--- a/src/accessories/WyzeMotionSensor.js
+++ b/src/accessories/WyzeMotionSensor.js
@@ -107,6 +107,7 @@ module.exports = class WyzeMotionSensor extends WyzeAccessory {
     if (device.conn_state === 0) {
       this.getOnCharacteristic().updateValue(noResponse);
     } else {
+      if (!device.device_params) return;
       this.getOnCharacteristic().updateValue(device.device_params.motion_state);
       this.getBatteryCharacteristic().updateValue(
         this.plugin.client.checkBatteryVoltage(device.device_params.voltage)

--- a/src/accessories/WyzePlug.js
+++ b/src/accessories/WyzePlug.js
@@ -10,7 +10,21 @@ module.exports = class WyzePlug extends WyzeAccessory {
   constructor(plugin, homeKitAccessory) {
     super(plugin, homeKitAccessory);
 
-    this.getOnCharacteristic().on("set", this.set.bind(this));
+    this.getOnCharacteristic()
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
+  }
+
+  async getOn() {
+    return this._switchState ?? false;
+  }
+
+  async setOn(value) {
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(
+        `[Plug] Setting power for "${this.display_name} (${this.mac})" to ${value}`
+      );
+    await this.plugin.client.plugPower(this.mac, this.product_model, value ? "1" : "0");
   }
 
   updateCharacteristics(device) {
@@ -21,7 +35,11 @@ module.exports = class WyzePlug extends WyzeAccessory {
     if (device.conn_state === 0) {
       this.getOnCharacteristic().updateValue(noResponse);
     } else {
-      this.getOnCharacteristic().updateValue(device.device_params.switch_state);
+      const switchState = device.device_params?.switch_state;
+      if (switchState != null) {
+        this._switchState = switchState;
+        this.getOnCharacteristic().updateValue(switchState);
+      }
     }
   }
 
@@ -51,21 +69,4 @@ module.exports = class WyzePlug extends WyzeAccessory {
     return this.getOutletService().getCharacteristic(Characteristic.On);
   }
 
-  async set(value, callback) {
-    if (this.plugin.config.pluginLoggingEnabled)
-      this.plugin.log(
-        `[Plug] Setting power for "${this.display_name} (${this.mac})" to ${value}`
-      );
-
-    try {
-      await this.plugin.client.plugPower(
-        this.mac,
-        this.product_model,
-        value ? "1" : "0"
-      );
-      callback();
-    } catch (e) {
-      callback(e);
-    }
-  }
 };

--- a/src/accessories/WyzeSwitch.js
+++ b/src/accessories/WyzeSwitch.js
@@ -114,7 +114,7 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
       this.plugin.log(
         `[Switch] Getting Current State of "${this.display_name} (${this.mac})" : "${this.switch_power}"`
       );
-    return this.switch_power;
+    return this.switch_power ?? false;
   }
 
   async handleOnSetWallSwitch(value) {
@@ -124,22 +124,12 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
       );
     try {
       if (this.single_press_type == SinglePressType.IOT) {
-        await this.plugin.client.wallSwitchIot(
-          this.mac,
-          this.product_model,
-          value ? true : false
-        );
-        this.switch_power = !!value;
-        this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
+        await this.plugin.client.wallSwitchIot(this.mac, this.product_model, value ? true : false);
       } else {
-        await this.plugin.client.wallSwitchPower(
-          this.mac,
-          this.product_model,
-          value ? true : false
-        );
-        this.switch_power = !!value;
-        this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
+        await this.plugin.client.wallSwitchPower(this.mac, this.product_model, value ? true : false);
       }
+      this.switch_power = !!value;
+      this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
     } catch (error) {
       this.plugin.log.error?.(
         `[Switch] Failed to set target state for "${this.display_name} (${this.mac})": ${error}`

--- a/src/accessories/WyzeSwitch.js
+++ b/src/accessories/WyzeSwitch.js
@@ -98,15 +98,6 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
           }
         }
 
-        if (
-          this.product_model === CommonModels.Palm &&
-          this.switch_power === undefined
-        ) {
-          this.switch_power = false;
-          this.wallSwitch
-            .getCharacteristic(Characteristic.On)
-            .updateValue(this.switch_power);
-        }
       } catch (error) {
         this.plugin.log.error?.(
           `[Switch] Failed to update "${this.display_name} (${this.mac})": ${error}`
@@ -132,41 +123,22 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
         `[Switch] Target State Set "${this.display_name} (${this.mac})" : "${value}"`
       );
     try {
-      if (this.product_model === CommonModels.Palm) {
-        const prefersIot =
-          this.single_press_type == SinglePressType.IOT ||
-          this.switch_iot !== undefined;
-
-        if (prefersIot) {
-          await this.plugin.client.wallSwitchIot(
-            this.mac,
-            this.product_model,
-            value ? true : false
-          );
-        } else {
-          await this.plugin.client.wallSwitchPower(
-            this.mac,
-            this.product_model,
-            value ? true : false
-          );
-        }
-
-        this.switch_power = !!value;
-        this.wallSwitch
-          .getCharacteristic(Characteristic.On)
-          .updateValue(this.switch_power);
-      } else if (this.single_press_type == SinglePressType.IOT) {
+      if (this.single_press_type == SinglePressType.IOT) {
         await this.plugin.client.wallSwitchIot(
           this.mac,
           this.product_model,
           value ? true : false
         );
+        this.switch_power = !!value;
+        this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
       } else {
         await this.plugin.client.wallSwitchPower(
           this.mac,
           this.product_model,
           value ? true : false
         );
+        this.switch_power = !!value;
+        this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
       }
     } catch (error) {
       this.plugin.log.error?.(

--- a/src/accessories/WyzeTemperatureHumidity.js
+++ b/src/accessories/WyzeTemperatureHumidity.js
@@ -136,6 +136,7 @@ module.exports = class WyzeTemperatureHumidity extends WyzeAccessory {
     if (device.conn_state === 0) {
       this.getHumidityCharacteristic().updateValue(noResponse);
     } else {
+      if (!device.device_params) return;
       this.getHumidityCharacteristic().updateValue(
         device.device_params.th_sensor_humidity
       );

--- a/src/accessories/WyzeThermostat.js
+++ b/src/accessories/WyzeThermostat.js
@@ -113,7 +113,6 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
       .onGet(this.handleTemperatureDisplayUnitsGet.bind(this))
       .onSet(this.handleTemperatureDisplayUnitsSet.bind(this));
 
-    this.updateCharacteristics();
   }
 
   async handleCurrentTemperatureGet() {
@@ -394,7 +393,8 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
     let response;
     try {
       response = await this.plugin.client.thermostatGetIotProp(this.mac);
-      let properties = response.data.props;
+      let properties = response?.data?.props;
+      if (!properties) return;
       const prop_key = Object.keys(properties);
       for (const element of prop_key) {
         const prop = element;


### PR DESCRIPTION
  ## Summary

  - **Crash prevention**: Added `device.device_params` null guards across all sensor
    accessories (Contact, Motion, Leak, Temp/Humidity, Camera, HMS) — stale cache
    entries on startup no longer throw
  - **WyzeAccessory**: Fixed dead concurrency guard (`updating` never set) and broken
    throttle (`lastTimestamp` never assigned); added outer try/catch for sync throws
    that escaped `.catch()`
  - **Modern HAP API**: Converted `on('set', callback)` → `onGet`/`onSet` in
    WyzePlug, WyzeLight, and WyzeMeshLight — compatible with both Homebridge 1.x
    (hap-nodejs 0.12.x) and 2.x (hap-nodejs 1.x)
  - **WyzeCamera**: Fixed `alarmAccessory` → `sirenAccessory` config key; added
    change-detection to suppress repeated privacy/notification log spam
  - **WyzeSwitch**: Removed dead `CommonModels.Palm` branches (`Palm` is `undefined`;
    Palm devices route to WyzeLockBoltV2); state now updated locally after successful set
  - **WyzeThermostat**: Removed premature `updateCharacteristics()` call from
    constructor (fired before auth was ready); added null guard on `response?.data?.props`
  - **WyzeLockBoltV2**: Null-check result before accessing `.code`
  - **WyzeHMS**: Throws with a clear message if device ID cannot be resolved
  - **Log noise**: Refresh count gated behind `pluginLoggingEnabled`; `_knownUnsupported`
    Set prevents repeated unsupported-device log spam; removed redundant cache-load log
  - **Dependencies**: Removed `homebridge-config-ui-x` (never imported; pulled in native
    binaries that fail to compile on Node 24); restored Node 18.17.0+ engine support;
    loosened `wyze-api` to `^1.1.12`