### PR TITLE
v0.5.58: Fix original Wyze Lock (YD.LO1) via wyze-api 1.1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.57",
+  "version": "0.5.58",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "urllib": "3.18.0",
     "utf8": "^3.0.0",
     "uuid-by-string": "4.0.0",
-    "wyze-api": "^1.1.12"
+    "wyze-api": "^1.1.14"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",


### PR DESCRIPTION
## Summary

- Bumps `wyze-api` floor to `^1.1.14` to pull in two Ford API bug fixes that caused `PARAM_SIGN_INVALID` / `PARAM_TIMESTAMP_INVALID` errors for the original Wyze Lock (YD.LO1)
- Updates the `src/wyze-api` submodule pointer to the merged commit (`ea5a9b4`) on jfarmer08/wyze-api
- No changes to plugin logic — this is purely a dependency bump

## Root cause (wyze-api fixes)

The original Wyze Lock uses the Ford API (`yd-saas-toc.wyzecam.com`). Two bugs in `wyze-api ≤1.1.12`:

1. **`fordCreatePayload` signed the wrong payload** — the HMAC signature was computed over the original payload before `access_token`, `key`, and `timestamp` were injected. The Ford API requires the signature to cover all fields.
2. **`getLockInfo` sent unsigned params** — `config.params` was assigned before `fordCreatePayload` was called, so the GET request went out with the unsigned (pre-signature) params.

Both fixed in [jfarmer08/wyze-api#46](https://github.com/jfarmer08/wyze-api/pull/46), published as `wyze-api@1.1.14`.

## Test plan

- [ ] Original Wyze Lock (YD.LO1) lock/unlock works without `PARAM_SIGN_INVALID` errors
- [ ] Lock Bolt V2 / Palm (IoT3 path) unaffected
- [ ] Other accessories unaffected

Fixes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)