### PR TITLE
 Bump to 0.5.61: optimistic HomeKit updates + lock/HMS/plug grace-period fixes + wyze-api 1.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 ## Releases
 
+### v0.5.59
+- Eliminate "waiting" tile state on lock/unlock commands: `setLockTargetState` now updates HomeKit optimistically and fires the API call in the background for both WyzeLockBoltV2 (Palm Lock, Lock Bolt V2) and WyzeLock (YD.LO1)
+- Add 15s command grace period on both lock types: fast poll skips updating lock state from the API during the grace window, preventing stale reads from reverting the optimistic HomeKit state before the Wyze API propagates
+- Skip fast poll when a full refresh ran within the last 10s — prevents redundant back-to-back API polls and double full refreshes after a fast-poll-detected change
+- Fix WyzeLock `updateCharacteristics` not pushing `LockTargetState` on physical lock/unlock — previously only `LockCurrentState` was updated, leaving HomeKit stuck in "waiting" after panel or physical state changes
+- Fix WyzeHMS security panel "waiting": `handleSecuritySystemTargetStateSet` now updates `SecuritySystemCurrentState` optimistically and fires `setHMSState` in the background
+- Optimistic on/off updates for WyzePlug, WyzeLight, WyzeMeshLight, and WyzeSwitch: setters update local state immediately and fire API calls in the background, eliminating HAP blocking
+- Add change detection to WyzePlug, WyzeLight, and WyzeMeshLight `updateCharacteristics`: on/off state is only pushed to HomeKit when it differs from local state, preventing 60s refresh from flickering tiles whose state was just set
+- WyzeSwitch: remove `throw` from `handleOnSetWallSwitch` error path — re-throwing caused HAP to put the tile in an error state; errors are now logged only
+- Add dev-only startup log line showing plugin version when running from a local git clone
+
 ### v0.5.58
 - Fix original Wyze Lock (YD.LO1) failing with `PARAM_SIGN_INVALID` / `PARAM_TIMESTAMP_INVALID` — bumps `wyze-api` to `1.1.14`, which corrects Ford API payload signing: signature is now computed after `access_token`, `key`, and `timestamp` are injected, and `getLockInfo` now sends signed parameters on the GET request. Lock Bolt V2, Lock Bolt Pro, and Palm Lock (IoT3 path) are unaffected.
 - Closes #300

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 ## Releases
 
+### v0.5.60
+- Differentiate command grace period by direction: locking still uses a 15s grace window, but unlocking now uses 90s to match how long the Wyze API actually takes to propagate an unlock, preventing the fast poll from reverting the optimistic "unlocked" tile back to "locked" for WyzeLock and WyzeLockBoltV2
+- Fix WyzeLock/WyzeLockBoltV2 `setLockTargetState` not updating `LockTargetState` alongside `LockCurrentState` on optimistic command updates
+- Gate new lock timing/command-ack debug logs behind `pluginLoggingEnabled`, consistent with the rest of the plugin
+
 ### v0.5.59
 - Eliminate "waiting" tile state on lock/unlock commands: `setLockTargetState` now updates HomeKit optimistically and fires the API call in the background for both WyzeLockBoltV2 (Palm Lock, Lock Bolt V2) and WyzeLock (YD.LO1)
 - Add 15s command grace period on both lock types: fast poll skips updating lock state from the API during the grace window, preventing stale reads from reverting the optimistic HomeKit state before the Wyze API propagates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 ## Releases
 
+### v0.5.61
+Fixes for regressions and gaps found in code review of the 0.5.59/0.5.60 optimistic-update work:
+- Fix WyzeLockBoltV2 lock/unlock commands treating a resolved-but-logically-failed IoT3 response (`result.code !== "1"`) as success — this check was dropped when the command path became fire-and-forget; it's now restored and clears the grace period on failure so HomeKit doesn't keep showing a command that never applied
+- Fix `refreshLockDevices` reusing `securityRefreshInterval` as both the fast-poll's own cadence and the "skip right after a full refresh" threshold — any config where `refreshInterval` <= `securityRefreshInterval` silently disabled lock fast-polling almost entirely; the skip window is now a fixed 10s constant, decoupled from user-configured intervals
+- Add the same optimistic-update grace period used by locks to WyzeHMS (security panel) and to the on/off setter in WyzePlug/WyzeLight/WyzeMeshLight — without it, a poll landing mid-command could revert the optimistic state back to a stale/transitional value, reproducing the exact flicker bug the grace period was built to fix for locks
+- Add a shared `armCommandGrace`/`clearCommandGrace`/`inCommandGrace` helper on the `WyzeAccessory` base class instead of copy-pasting the grace-period pattern into each accessory
+- On command failure (reject or logical failure), clear the grace period immediately across WyzeLock, WyzeLockBoltV2, WyzeHMS, WyzePlug, WyzeLight, and WyzeMeshLight so the next poll can correct the optimistic state right away instead of waiting out the full 15s/90s window
+- Fix WyzePlug/WyzeLight/WyzeMeshLight command errors being swallowed with `.catch(() => {})` and zero logging — errors are now logged when `pluginLoggingEnabled` is set, consistent with every other accessory
+- Known limitation (not changed): the grace period can still mask a genuine physical/keypad lock change or a third-party app change that happens to match the pre-command state, for the duration of the window — this is an inherent trade-off of optimistic updates and isn't fixable without the Wyze API surfacing a freshness/version signal
+- Reviewed but not changed: WyzeSwitch's `handleOnSetWallSwitch` has no grace period, so a failed command already self-corrects on the next full refresh (unlike the accessories above); the only gap is the removed `throw`, which is intentional per v0.5.59 (avoids putting the tile in a HAP error state)
+- Reviewed but not changed: `runLockFastPollLoop`'s pre-existing `securityRefreshInterval || DEFAULT_SECURITY_REFRESH_INTERVAL` treats an explicit `0` as unset; this predates this diff and is left as-is
+
 ### v0.5.60
 - Differentiate command grace period by direction: locking still uses a 15s grace window, but unlocking now uses 90s to match how long the Wyze API actually takes to propagate an unlock, preventing the fast poll from reverting the optimistic "unlocked" tile back to "locked" for WyzeLock and WyzeLockBoltV2
 - Fix WyzeLock/WyzeLockBoltV2 `setLockTargetState` not updating `LockTargetState` alongside `LockCurrentState` on optimistic command updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.60",
+  "version": "0.5.61",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",
@@ -34,7 +34,7 @@
     "urllib": "3.18.0",
     "utf8": "^3.0.0",
     "uuid-by-string": "4.0.0",
-    "wyze-api": "^1.1.14"
+    "wyze-api": "^1.1.15"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.59",
+  "version": "0.5.60",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "0.5.58",
+  "version": "0.5.59",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/WyzeSmartHome.js
+++ b/src/WyzeSmartHome.js
@@ -1,3 +1,5 @@
+const fs = require('fs')
+const path = require('path')
 const { homebridge, Accessory, UUIDGen } = require('./types')
 const { OutdoorPlugModels, PlugModels, CommonModels, CameraModels, LeakSensorModels,
   TemperatureHumidityModels, LockModels, LockBoltV2Models, MotionSensorModels, ContactSensorModels, LightModels,
@@ -42,6 +44,7 @@ module.exports = class WyzeSmartHome {
     this.accessories = []
     this._fastPollStats = new Map()
     this._knownUnsupported = new Set()
+    this._lastFullRefreshAt = 0
 
     this.api.on('didFinishLaunching', this.didFinishLaunching.bind(this))
   }
@@ -86,6 +89,10 @@ module.exports = class WyzeSmartHome {
   }
 
   didFinishLaunching() {
+    if (fs.existsSync(path.join(__dirname, '..', '.git'))) {
+      const { version } = require('../package.json')
+      this.log(`[Plugin] Local dev build v${version}`)
+    }
     this.runLoop()
     this.runLockFastPollLoop()
   }
@@ -117,6 +124,9 @@ module.exports = class WyzeSmartHome {
   }
 
   async refreshLockDevices() {
+    const interval = this.config.securityRefreshInterval || DEFAULT_SECURITY_REFRESH_INTERVAL
+    if (Date.now() - this._lastFullRefreshAt < interval) return
+
     const targets = this.accessories.filter(a => FAST_POLL_CLASSES.has(a.constructor) && a.lastDevice)
     if (targets.length === 0) return
 
@@ -159,6 +169,7 @@ module.exports = class WyzeSmartHome {
       const devices = objectList.data.device_list
 
       await this.loadDevices(devices, timestamp)
+      this._lastFullRefreshAt = Date.now()
       if (this.config.pluginLoggingEnabled) this.log(`Refreshed ${this.accessories.length}/${devices.length} devices${fastPollSummary}`)
     } catch (e) {
       this.log.error(`Error getting devices: ${e}`)

--- a/src/WyzeSmartHome.js
+++ b/src/WyzeSmartHome.js
@@ -26,6 +26,14 @@ const PLATFORM_NAME = 'WyzeSmartHome'
 const DEFAULT_REFRESH_INTERVAL = 30000
 const DEFAULT_SECURITY_REFRESH_INTERVAL = 10000
 
+// Fixed window (independent of user-configured refresh intervals) used to skip
+// a fast poll immediately after a full refresh — avoids a redundant back-to-back
+// API call. Deliberately NOT tied to securityRefreshInterval: that value is also
+// the fast poll's own tick cadence, so reusing it here could make the skip
+// window as long as (or longer than) the poll loop itself and silently disable
+// fast polling whenever refreshInterval <= securityRefreshInterval.
+const FULL_REFRESH_SKIP_WINDOW_MS = 10000
+
 // Accessories that make their own API call in updateCharacteristics and return
 // a boolean indicating whether state changed — safe to fast-poll independently.
 const FAST_POLL_CLASSES = new Set([WyzeLock, WyzeLockBoltV2])
@@ -124,8 +132,7 @@ module.exports = class WyzeSmartHome {
   }
 
   async refreshLockDevices() {
-    const interval = this.config.securityRefreshInterval || DEFAULT_SECURITY_REFRESH_INTERVAL
-    if (Date.now() - this._lastFullRefreshAt < interval) return
+    if (Date.now() - this._lastFullRefreshAt < FULL_REFRESH_SKIP_WINDOW_MS) return
 
     const targets = this.accessories.filter(a => FAST_POLL_CLASSES.has(a.constructor) && a.lastDevice)
     if (targets.length === 0) return

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -105,4 +105,21 @@ module.exports = class WyzeAccessory {
   sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+
+  // Optimistic-update grace period: after firing a command, arm this for the
+  // command's expected propagation time so a poll landing before the Wyze API
+  // catches up doesn't revert the optimistic HomeKit state back to stale data.
+  armCommandGrace(ms) {
+    this._commandGraceUntil = Date.now() + ms;
+  }
+
+  // Call when a command is known to have failed so the next poll (rather than
+  // the full grace window) is free to correct the optimistic state.
+  clearCommandGrace() {
+    this._commandGraceUntil = 0;
+  }
+
+  inCommandGrace() {
+    return Date.now() <= (this._commandGraceUntil || 0);
+  }
 };

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -87,11 +87,21 @@ module.exports = class WyzeHMS extends WyzeAccessory {
           this.display_name
         }" : "${this.convertHomeKitStateToHmsState(value)}"`
       );
-    await this.getHmsID();
-    await this.plugin.client.setHMSState(
-      this.hmsId,
-      this.convertHomeKitStateToHmsState(value)
-    );
+
+    // Optimistic update so the panel clears immediately.
+    const hmsState = this.convertHomeKitStateToHmsState(value);
+    this.hmsStatus = hmsState === "off" ? "disarm" : hmsState;
+    const homeKitState = this.convertHmsStateToHomeKitState(this.hmsStatus);
+    this.securityService
+      .getCharacteristic(Characteristic.SecuritySystemCurrentState)
+      .updateValue(homeKitState);
+
+    this.getHmsID()
+      .then(() => this.plugin.client.setHMSState(this.hmsId, hmsState))
+      .catch((e) => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[HMS] Command error for "${this.display_name}": ${e}`);
+      });
   }
 
   convertHmsStateToHomeKitState(hmsState) {

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -53,10 +53,15 @@ module.exports = class WyzeHMS extends WyzeAccessory {
       const response = await this.plugin.client.monitoringProfileStateStatus(
         this.hmsId
       );
-      this.hmsStatus = response.message;
-      this.securityService
-        .getCharacteristic(Characteristic.SecuritySystemCurrentState)
-        .updateValue(this.convertHmsStateToHomeKitState(this.hmsStatus));
+      // Skip during grace period after a command — the API can report a
+      // transient "changing" status while the real arm/disarm propagates,
+      // which would otherwise revert the optimistic update we just made.
+      if (!this.inCommandGrace()) {
+        this.hmsStatus = response.message;
+        this.securityService
+          .getCharacteristic(Characteristic.SecuritySystemCurrentState)
+          .updateValue(this.convertHmsStateToHomeKitState(this.hmsStatus));
+      }
     }
   }
 
@@ -88,9 +93,12 @@ module.exports = class WyzeHMS extends WyzeAccessory {
         }" : "${this.convertHomeKitStateToHmsState(value)}"`
       );
 
-    // Optimistic update so the panel clears immediately.
+    // Optimistic update so the panel clears immediately. Grace period
+    // prevents the next full refresh from reverting this before the API
+    // propagates (or from re-showing a stale "changing" status).
     const hmsState = this.convertHomeKitStateToHmsState(value);
     this.hmsStatus = hmsState === "off" ? "disarm" : hmsState;
+    this.armCommandGrace(15000);
     const homeKitState = this.convertHmsStateToHomeKitState(this.hmsStatus);
     this.securityService
       .getCharacteristic(Characteristic.SecuritySystemCurrentState)
@@ -99,6 +107,9 @@ module.exports = class WyzeHMS extends WyzeAccessory {
     this.getHmsID()
       .then(() => this.plugin.client.setHMSState(this.hmsId, hmsState))
       .catch((e) => {
+        // Command never went through — let the next full refresh correct
+        // the optimistic state instead of holding it for the full grace window.
+        this.clearCommandGrace();
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(`[HMS] Command error for "${this.display_name}": ${e}`);
       });

--- a/src/accessories/WyzeLight.js
+++ b/src/accessories/WyzeLight.js
@@ -44,7 +44,7 @@ module.exports = class WyzeLight extends WyzeAccessory {
         );
       }
       const switchState = device.device_params?.switch_state;
-      if (switchState != null) {
+      if (switchState != null && switchState !== this._switchState) {
         this._switchState = switchState;
         this.getCharacteristic(Characteristic.On).updateValue(switchState);
       }
@@ -111,7 +111,8 @@ module.exports = class WyzeLight extends WyzeAccessory {
       this.plugin.log(
         `[Light] Setting power for ${this.mac} (${this.display_name}) to ${value}`
       );
-    await this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0");
+    this._switchState = value ? 1 : 0;
+    this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0").catch(() => {});
   }
 
   async setBrightness(value) {
@@ -120,7 +121,7 @@ module.exports = class WyzeLight extends WyzeAccessory {
       this.plugin.log(
         `[Light] Setting brightness for ${this.mac} (${this.display_name}) to ${value}`
       );
-    await this.plugin.client.setBrightness(this.mac, this.product_model, value);
+    this.plugin.client.setBrightness(this.mac, this.product_model, value).catch(() => {});
   }
 
   async setColorTemperature(value) {
@@ -131,6 +132,6 @@ module.exports = class WyzeLight extends WyzeAccessory {
       this.plugin.log(
         `[Light] Setting color temperature for ${this.mac} (${this.display_name}) to ${value} (${wyzeValue})`
       );
-    await this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue);
+    this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue).catch(() => {});
   }
 };

--- a/src/accessories/WyzeLight.js
+++ b/src/accessories/WyzeLight.js
@@ -44,7 +44,7 @@ module.exports = class WyzeLight extends WyzeAccessory {
         );
       }
       const switchState = device.device_params?.switch_state;
-      if (switchState != null && switchState !== this._switchState) {
+      if (switchState != null && switchState !== this._switchState && !this.inCommandGrace()) {
         this._switchState = switchState;
         this.getCharacteristic(Characteristic.On).updateValue(switchState);
       }
@@ -112,7 +112,12 @@ module.exports = class WyzeLight extends WyzeAccessory {
         `[Light] Setting power for ${this.mac} (${this.display_name}) to ${value}`
       );
     this._switchState = value ? 1 : 0;
-    this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0").catch(() => {});
+    this.armCommandGrace(15000);
+    this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0").catch((e) => {
+      this.clearCommandGrace();
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Light] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   async setBrightness(value) {
@@ -121,7 +126,10 @@ module.exports = class WyzeLight extends WyzeAccessory {
       this.plugin.log(
         `[Light] Setting brightness for ${this.mac} (${this.display_name}) to ${value}`
       );
-    this.plugin.client.setBrightness(this.mac, this.product_model, value).catch(() => {});
+    this.plugin.client.setBrightness(this.mac, this.product_model, value).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Light] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   async setColorTemperature(value) {
@@ -132,6 +140,9 @@ module.exports = class WyzeLight extends WyzeAccessory {
       this.plugin.log(
         `[Light] Setting color temperature for ${this.mac} (${this.display_name}) to ${value} (${wyzeValue})`
       );
-    this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue).catch(() => {});
+    this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Light] Command error for "${this.display_name}": ${e}`);
+    });
   }
 };

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -13,7 +13,6 @@ module.exports = class WyzeLock extends WyzeAccessory {
     this.hardlock = null;
     this.door_open_status = null;
     this.lockPower = null;
-    this._commandGraceUntil = 0;
 
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
@@ -150,7 +149,7 @@ module.exports = class WyzeLock extends WyzeAccessory {
         switch (prop) {
           case "hardlock":
             // Door Locked Status — skip during grace period after a command
-            if (Date.now() > this._commandGraceUntil) {
+            if (!this.inCommandGrace()) {
               this.hardlock = lockerStatusProperties[prop];
               const lockState = this.plugin.client.getLockState(lockerStatusProperties[prop]);
               this.lockService
@@ -240,7 +239,7 @@ module.exports = class WyzeLock extends WyzeAccessory {
     // Grace period prevents the fast poll from reverting this before the API propagates.
     // Locking propagates in ~15s; unlocking takes ~90s on the Wyze Ford API endpoint.
     this.hardlock = locking ? 1 : 2;
-    this._commandGraceUntil = Date.now() + (locking ? 15000 : 90000);
+    this.armCommandGrace(locking ? 15000 : 90000);
     this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(
       locking ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED
     );
@@ -259,6 +258,9 @@ module.exports = class WyzeLock extends WyzeAccessory {
           this.plugin.log(`[Lock] Command ACK in ${Date.now() - cmdT0}ms for "${this.display_name}"`);
       })
       .catch((e) => {
+        // Command failed — don't leave the optimistic state stuck for the
+        // full grace window; let the next poll correct it.
+        this.clearCommandGrace();
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(`[Lock] Command error after ${Date.now() - cmdT0}ms for "${this.display_name}": ${e}`);
       });

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -104,10 +104,12 @@ module.exports = class WyzeLock extends WyzeAccessory {
       const prevDoorStatus = this.door_open_status;
       const prevPower = this.lockPower;
 
+      const apiT0 = Date.now();
       const propertyList = await this.plugin.client.getLockInfo(
         this.mac,
         this.product_model
       );
+      const apiMs = Date.now() - apiT0;
       let lockProperties = propertyList?.device;
       if (!lockProperties) return false;
       const prop_key = Object.keys(lockProperties);
@@ -160,6 +162,11 @@ module.exports = class WyzeLock extends WyzeAccessory {
             }
             break;
         }
+      }
+
+      if (this.plugin.config.pluginLoggingEnabled) {
+        const hkMs = Date.now() - apiT0 - apiMs;
+        this.plugin.log(`[Lock] Timing for "${this.display_name}": API ${apiMs}ms | HK update ${hkMs}ms`);
       }
 
       return this.hardlock !== prevHardlock ||
@@ -231,24 +238,30 @@ module.exports = class WyzeLock extends WyzeAccessory {
 
     // Optimistically update HomeKit immediately so the tile clears "waiting".
     // Grace period prevents the fast poll from reverting this before the API propagates.
+    // Locking propagates in ~15s; unlocking takes ~90s on the Wyze Ford API endpoint.
     this.hardlock = locking ? 1 : 2;
-    this._commandGraceUntil = Date.now() + 15000;
-    this.lockService
-      .getCharacteristic(Characteristic.LockCurrentState)
-      .updateValue(
-        locking
-          ? Characteristic.LockCurrentState.SECURED
-          : Characteristic.LockCurrentState.UNSECURED
-      );
+    this._commandGraceUntil = Date.now() + (locking ? 15000 : 90000);
+    this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(
+      locking ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED
+    );
+    this.lockService.getCharacteristic(Characteristic.LockTargetState).updateValue(
+      locking ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED
+    );
 
+    const cmdT0 = Date.now();
     this.plugin.client.controlLock(
       this.mac,
       this.product_model,
       locking ? "remoteLock" : "remoteUnlock"
-    ).catch((e) => {
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(`[Lock] Command error for "${this.display_name} [${this.model_name}] (${this.mac})": ${e}`);
-    });
+    )
+      .then(() => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[Lock] Command ACK in ${Date.now() - cmdT0}ms for "${this.display_name}"`);
+      })
+      .catch((e) => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[Lock] Command error after ${Date.now() - cmdT0}ms for "${this.display_name}": ${e}`);
+      });
   }
 
 };

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -13,6 +13,7 @@ module.exports = class WyzeLock extends WyzeAccessory {
     this.hardlock = null;
     this.door_open_status = null;
     this.lockPower = null;
+    this._commandGraceUntil = 0;
 
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
@@ -146,13 +147,17 @@ module.exports = class WyzeLock extends WyzeAccessory {
         const prop = element;
         switch (prop) {
           case "hardlock":
-            // Door Locked Status
-            this.lockService
-              .getCharacteristic(Characteristic.LockCurrentState)
-              .updateValue(
-                this.plugin.client.getLockState(lockerStatusProperties[prop])
-              );
-            this.hardlock = lockerStatusProperties[prop];
+            // Door Locked Status — skip during grace period after a command
+            if (Date.now() > this._commandGraceUntil) {
+              this.hardlock = lockerStatusProperties[prop];
+              const lockState = this.plugin.client.getLockState(lockerStatusProperties[prop]);
+              this.lockService
+                .getCharacteristic(Characteristic.LockCurrentState)
+                .updateValue(lockState);
+              this.lockService
+                .getCharacteristic(Characteristic.LockTargetState)
+                .updateValue(lockState);
+            }
             break;
         }
       }
@@ -220,21 +225,30 @@ module.exports = class WyzeLock extends WyzeAccessory {
 
   async setLockTargetState(targetState) {
     if (this.plugin.config.pluginLoggingEnabled)
-      this.plugin.log(`[Lock] Setting Target State "${targetState}"`); // this is zero or 1
-    await this.plugin.client.controlLock(
+      this.plugin.log(`[Lock] Setting Target State "${this.display_name} [${this.model_name}] (${this.mac}) to ${targetState}"`);
+
+    const locking = targetState === Characteristic.LockTargetState.SECURED;
+
+    // Optimistically update HomeKit immediately so the tile clears "waiting".
+    // Grace period prevents the fast poll from reverting this before the API propagates.
+    this.hardlock = locking ? 1 : 2;
+    this._commandGraceUntil = Date.now() + 15000;
+    this.lockService
+      .getCharacteristic(Characteristic.LockCurrentState)
+      .updateValue(
+        locking
+          ? Characteristic.LockCurrentState.SECURED
+          : Characteristic.LockCurrentState.UNSECURED
+      );
+
+    this.plugin.client.controlLock(
       this.mac,
       this.product_model,
-      targetState === Characteristic.LockTargetState.SECURED
-        ? "remoteLock"
-        : "remoteUnlock"
-    );
-
-    this.lockService.setCharacteristic(
-      Characteristic.LockCurrentState,
-      targetState === Characteristic.LockTargetState.SECURED
-        ? Characteristic.LockCurrentState.SECURED
-        : Characteristic.LockCurrentState.UNSECURED
-    );
+      locking ? "remoteLock" : "remoteUnlock"
+    ).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Lock] Command error for "${this.display_name} [${this.model_name}] (${this.mac})": ${e}`);
+    });
   }
 
 };

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -105,7 +105,9 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     try {
       // Palm Lock (DX_PVLOC) intentionally uses lockBoltV2GetProperties — it supports all 6 props
       // and palmLockGetProperties in wyze-api is missing door-status + power-source.
+      const apiT0 = Date.now();
       const result = await this.plugin.client.lockBoltV2GetProperties(this.mac, this.product_model);
+      const apiMs = Date.now() - apiT0;
       if (!result || result.code !== "1") {
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(
@@ -189,6 +191,12 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
           .getService(Service.AccessoryInformation)
           .setCharacteristic(Characteristic.FirmwareRevision, this.firmwareVersion);
       }
+
+      if (this.plugin.config.pluginLoggingEnabled) {
+        const hkMs = Date.now() - apiT0 - apiMs;
+        const inGrace = Date.now() < this._commandGraceUntil;
+        this.plugin.log(`[Lock] Timing for "${this.display_name}": API ${apiMs}ms | HK update ${hkMs}ms | locked=${props["lock::lock-status"]} | grace=${inGrace}`);
+      }
     } catch (e) {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
@@ -265,25 +273,32 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
 
     // Optimistically update HomeKit immediately so the tile clears "waiting".
     // Grace period prevents the fast poll from reverting this before the API propagates.
+    // Locking propagates in ~15s; unlocking takes ~90s on the Wyze IoT3 endpoint.
     this.isLocked = targetState === Characteristic.LockTargetState.SECURED;
-    this._commandGraceUntil = Date.now() + 15000;
-    this.lockService
-      .getCharacteristic(Characteristic.LockCurrentState)
-      .updateValue(
-        this.isLocked
-          ? Characteristic.LockCurrentState.SECURED
-          : Characteristic.LockCurrentState.UNSECURED
-      );
+    this._commandGraceUntil = Date.now() + (this.isLocked ? 15000 : 90000);
+    const hkLockState = this.isLocked
+      ? Characteristic.LockCurrentState.SECURED
+      : Characteristic.LockCurrentState.UNSECURED;
+    this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(hkLockState);
+    this.lockService.getCharacteristic(Characteristic.LockTargetState).updateValue(
+      this.isLocked
+        ? Characteristic.LockTargetState.SECURED
+        : Characteristic.LockTargetState.UNSECURED
+    );
 
+    const cmdT0 = Date.now();
     const call = this.isLocked
       ? this.plugin.client.lockBoltV2Lock(this.mac, this.product_model)
       : this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
 
-    call.catch((e) => {
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(
-          `[Lock] Command error for "${this.display_name} [${this.model_name}] (${this.mac})": ${e}`
-        );
-    });
+    call
+      .then(() => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[Lock] Command ACK in ${Date.now() - cmdT0}ms for "${this.display_name}"`);
+      })
+      .catch((e) => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[Lock] Command error after ${Date.now() - cmdT0}ms for "${this.display_name}": ${e}`);
+      });
   }
 };

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -15,6 +15,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     this.batteryLevel = 100;
     this.chargingState = 0;
     this.firmwareVersion = "";
+    this._commandGraceUntil = 0;
 
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
@@ -129,21 +130,25 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
       }
 
       if (props["lock::lock-status"] !== undefined) {
-        this.isLocked = props["lock::lock-status"];
-        this.lockService
-          .getCharacteristic(Characteristic.LockCurrentState)
-          .updateValue(
-            this.isLocked
-              ? Characteristic.LockCurrentState.SECURED
-              : Characteristic.LockCurrentState.UNSECURED
-          );
-        this.lockService
-          .getCharacteristic(Characteristic.LockTargetState)
-          .updateValue(
-            this.isLocked
-              ? Characteristic.LockTargetState.SECURED
-              : Characteristic.LockTargetState.UNSECURED
-          );
+        // Skip during grace period after a command to avoid reverting an
+        // optimistic update before the API has propagated the change.
+        if (Date.now() > this._commandGraceUntil) {
+          this.isLocked = props["lock::lock-status"];
+          this.lockService
+            .getCharacteristic(Characteristic.LockCurrentState)
+            .updateValue(
+              this.isLocked
+                ? Characteristic.LockCurrentState.SECURED
+                : Characteristic.LockCurrentState.UNSECURED
+            );
+          this.lockService
+            .getCharacteristic(Characteristic.LockTargetState)
+            .updateValue(
+              this.isLocked
+                ? Characteristic.LockTargetState.SECURED
+                : Characteristic.LockTargetState.UNSECURED
+            );
+        }
       }
 
       if (props["lock::door-status"] !== undefined) {
@@ -258,29 +263,27 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         `[Lock] Setting Target State "${this.display_name} [${this.model_name}] (${this.mac}) to ${targetState}"`
       );
 
-    try {
-      const result = targetState === Characteristic.LockTargetState.SECURED
-        ? await this.plugin.client.lockBoltV2Lock(this.mac, this.product_model)
-        : await this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
-      if (!result || result.code !== "1") {
-        if (this.plugin.config.pluginLoggingEnabled)
-          this.plugin.log(
-            `[Lock] Command failed for "${this.display_name} [${this.model_name}] (${this.mac})": ${result?.msg ?? 'no response'}`
-          );
-        return;
-      }
-      this.isLocked = targetState === Characteristic.LockTargetState.SECURED;
-      this.lockService.setCharacteristic(
-        Characteristic.LockCurrentState,
+    // Optimistically update HomeKit immediately so the tile clears "waiting".
+    // Grace period prevents the fast poll from reverting this before the API propagates.
+    this.isLocked = targetState === Characteristic.LockTargetState.SECURED;
+    this._commandGraceUntil = Date.now() + 15000;
+    this.lockService
+      .getCharacteristic(Characteristic.LockCurrentState)
+      .updateValue(
         this.isLocked
           ? Characteristic.LockCurrentState.SECURED
           : Characteristic.LockCurrentState.UNSECURED
       );
-    } catch (e) {
+
+    const call = this.isLocked
+      ? this.plugin.client.lockBoltV2Lock(this.mac, this.product_model)
+      : this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
+
+    call.catch((e) => {
       if (this.plugin.config.pluginLoggingEnabled)
         this.plugin.log(
-          `[Lock] Error setting lock "${this.display_name} [${this.model_name}] (${this.mac})": ${e}`
+          `[Lock] Command error for "${this.display_name} [${this.model_name}] (${this.mac})": ${e}`
         );
-    }
+    });
   }
 };

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -15,7 +15,6 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     this.batteryLevel = 100;
     this.chargingState = 0;
     this.firmwareVersion = "";
-    this._commandGraceUntil = 0;
 
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
@@ -134,7 +133,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
       if (props["lock::lock-status"] !== undefined) {
         // Skip during grace period after a command to avoid reverting an
         // optimistic update before the API has propagated the change.
-        if (Date.now() > this._commandGraceUntil) {
+        if (!this.inCommandGrace()) {
           this.isLocked = props["lock::lock-status"];
           this.lockService
             .getCharacteristic(Characteristic.LockCurrentState)
@@ -194,8 +193,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
 
       if (this.plugin.config.pluginLoggingEnabled) {
         const hkMs = Date.now() - apiT0 - apiMs;
-        const inGrace = Date.now() < this._commandGraceUntil;
-        this.plugin.log(`[Lock] Timing for "${this.display_name}": API ${apiMs}ms | HK update ${hkMs}ms | locked=${props["lock::lock-status"]} | grace=${inGrace}`);
+        this.plugin.log(`[Lock] Timing for "${this.display_name}": API ${apiMs}ms | HK update ${hkMs}ms | locked=${props["lock::lock-status"]} | grace=${this.inCommandGrace()}`);
       }
     } catch (e) {
       if (this.plugin.config.pluginLoggingEnabled)
@@ -275,7 +273,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     // Grace period prevents the fast poll from reverting this before the API propagates.
     // Locking propagates in ~15s; unlocking takes ~90s on the Wyze IoT3 endpoint.
     this.isLocked = targetState === Characteristic.LockTargetState.SECURED;
-    this._commandGraceUntil = Date.now() + (this.isLocked ? 15000 : 90000);
+    this.armCommandGrace(this.isLocked ? 15000 : 90000);
     const hkLockState = this.isLocked
       ? Characteristic.LockCurrentState.SECURED
       : Characteristic.LockCurrentState.UNSECURED;
@@ -292,11 +290,20 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
       : this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
 
     call
-      .then(() => {
+      .then((result) => {
+        if (!result || result.code !== "1") {
+          // IoT3 resolved without throwing but reported a logical failure —
+          // don't leave HomeKit showing a command that never actually applied.
+          this.clearCommandGrace();
+          if (this.plugin.config.pluginLoggingEnabled)
+            this.plugin.log(`[Lock] Command failed for "${this.display_name}": ${result?.msg ?? 'no response'}`);
+          return;
+        }
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(`[Lock] Command ACK in ${Date.now() - cmdT0}ms for "${this.display_name}"`);
       })
       .catch((e) => {
+        this.clearCommandGrace();
         if (this.plugin.config.pluginLoggingEnabled)
           this.plugin.log(`[Lock] Command error after ${Date.now() - cmdT0}ms for "${this.display_name}": ${e}`);
       });

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -40,7 +40,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.getCharacteristic(Characteristic.On).updateValue(noResponse);
     } else {
       const switchState = device.device_params?.switch_state;
-      if (switchState != null) {
+      if (switchState != null && switchState !== this._switchState) {
         this._switchState = switchState;
         this.getCharacteristic(Characteristic.On).updateValue(switchState);
       }
@@ -154,7 +154,8 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.plugin.log(
         `[MeshLight] Setting power for "${this.display_name} (${this.mac})" to ${value}"`
       );
-    await this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0");
+    this._switchState = value ? 1 : 0;
+    this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0").catch(() => {});
   }
 
   async setBrightness(value) {
@@ -162,7 +163,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.plugin.log(
         `[MeshLight] Setting brightness for "${this.display_name} (${this.mac}) to ${value}"`
       );
-    await this.plugin.client.setMeshBrightness(this.mac, this.product_model, value);
+    this.plugin.client.setMeshBrightness(this.mac, this.product_model, value).catch(() => {});
   }
 
   async setColorTemperature(value) {
@@ -173,7 +174,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.plugin.log(
         `[MeshLight] Setting color temperature for "${this.display_name} (${this.mac}) to ${value} : ${wyzeValue}"`
       );
-    await this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue);
+    this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue).catch(() => {});
   }
 
   async setHue(value) {
@@ -187,7 +188,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
       hexValue = hexValue.replace("#", "");
       if (this.plugin.config.pluginLoggingEnabled) this.plugin.log(hexValue);
-      await this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue);
+      this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue).catch(() => {});
       this.cacheUpdated = false;
     } else {
       this.cacheUpdated = true;
@@ -208,7 +209,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     if (this.cacheUpdated) {
       let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
       hexValue = hexValue.replace("#", "");
-      await this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue);
+      this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue).catch(() => {});
       this.cacheUpdated = false;
     } else {
       this.cacheUpdated = true;

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -40,7 +40,7 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.getCharacteristic(Characteristic.On).updateValue(noResponse);
     } else {
       const switchState = device.device_params?.switch_state;
-      if (switchState != null && switchState !== this._switchState) {
+      if (switchState != null && switchState !== this._switchState && !this.inCommandGrace()) {
         this._switchState = switchState;
         this.getCharacteristic(Characteristic.On).updateValue(switchState);
       }
@@ -155,7 +155,12 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
         `[MeshLight] Setting power for "${this.display_name} (${this.mac})" to ${value}"`
       );
     this._switchState = value ? 1 : 0;
-    this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0").catch(() => {});
+    this.armCommandGrace(15000);
+    this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0").catch((e) => {
+      this.clearCommandGrace();
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   async setBrightness(value) {
@@ -163,7 +168,10 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.plugin.log(
         `[MeshLight] Setting brightness for "${this.display_name} (${this.mac}) to ${value}"`
       );
-    this.plugin.client.setMeshBrightness(this.mac, this.product_model, value).catch(() => {});
+    this.plugin.client.setMeshBrightness(this.mac, this.product_model, value).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   async setColorTemperature(value) {
@@ -174,7 +182,10 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.plugin.log(
         `[MeshLight] Setting color temperature for "${this.display_name} (${this.mac}) to ${value} : ${wyzeValue}"`
       );
-    this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue).catch(() => {});
+    this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   async setHue(value) {
@@ -188,7 +199,10 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
       hexValue = hexValue.replace("#", "");
       if (this.plugin.config.pluginLoggingEnabled) this.plugin.log(hexValue);
-      this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue).catch(() => {});
+      this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue).catch((e) => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+      });
       this.cacheUpdated = false;
     } else {
       this.cacheUpdated = true;
@@ -209,7 +223,10 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     if (this.cacheUpdated) {
       let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
       hexValue = hexValue.replace("#", "");
-      this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue).catch(() => {});
+      this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue).catch((e) => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+      });
       this.cacheUpdated = false;
     } else {
       this.cacheUpdated = true;

--- a/src/accessories/WyzePlug.js
+++ b/src/accessories/WyzePlug.js
@@ -24,7 +24,8 @@ module.exports = class WyzePlug extends WyzeAccessory {
       this.plugin.log(
         `[Plug] Setting power for "${this.display_name} (${this.mac})" to ${value}`
       );
-    await this.plugin.client.plugPower(this.mac, this.product_model, value ? "1" : "0");
+    this._switchState = value ? 1 : 0;
+    this.plugin.client.plugPower(this.mac, this.product_model, value ? "1" : "0").catch(() => {});
   }
 
   updateCharacteristics(device) {
@@ -36,7 +37,7 @@ module.exports = class WyzePlug extends WyzeAccessory {
       this.getOnCharacteristic().updateValue(noResponse);
     } else {
       const switchState = device.device_params?.switch_state;
-      if (switchState != null) {
+      if (switchState != null && switchState !== this._switchState) {
         this._switchState = switchState;
         this.getOnCharacteristic().updateValue(switchState);
       }

--- a/src/accessories/WyzePlug.js
+++ b/src/accessories/WyzePlug.js
@@ -25,7 +25,12 @@ module.exports = class WyzePlug extends WyzeAccessory {
         `[Plug] Setting power for "${this.display_name} (${this.mac})" to ${value}`
       );
     this._switchState = value ? 1 : 0;
-    this.plugin.client.plugPower(this.mac, this.product_model, value ? "1" : "0").catch(() => {});
+    this.armCommandGrace(15000);
+    this.plugin.client.plugPower(this.mac, this.product_model, value ? "1" : "0").catch((e) => {
+      this.clearCommandGrace();
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Plug] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   updateCharacteristics(device) {
@@ -37,7 +42,7 @@ module.exports = class WyzePlug extends WyzeAccessory {
       this.getOnCharacteristic().updateValue(noResponse);
     } else {
       const switchState = device.device_params?.switch_state;
-      if (switchState != null && switchState !== this._switchState) {
+      if (switchState != null && switchState !== this._switchState && !this.inCommandGrace()) {
         this._switchState = switchState;
         this.getOnCharacteristic().updateValue(switchState);
       }

--- a/src/accessories/WyzeSwitch.js
+++ b/src/accessories/WyzeSwitch.js
@@ -122,19 +122,17 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
       this.plugin.log(
         `[Switch] Target State Set "${this.display_name} (${this.mac})" : "${value}"`
       );
-    try {
-      if (this.single_press_type == SinglePressType.IOT) {
-        await this.plugin.client.wallSwitchIot(this.mac, this.product_model, value ? true : false);
-      } else {
-        await this.plugin.client.wallSwitchPower(this.mac, this.product_model, value ? true : false);
-      }
-      this.switch_power = !!value;
-      this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
-    } catch (error) {
+    this.switch_power = !!value;
+    this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
+
+    const call = this.single_press_type == SinglePressType.IOT
+      ? this.plugin.client.wallSwitchIot(this.mac, this.product_model, !!value)
+      : this.plugin.client.wallSwitchPower(this.mac, this.product_model, !!value);
+
+    call.catch((error) => {
       this.plugin.log.error?.(
         `[Switch] Failed to set target state for "${this.display_name} (${this.mac})": ${error}`
       );
-      throw error;
-    }
+    });
   }
 };


### PR DESCRIPTION
  ## Summary
  
  v0.5.59 added optimistic HomeKit updates (locks, HMS, plug, light, mesh light, switch) so
  tiles stop showing "waiting" — the tile updates immediately and the Wyze API call fires in
  the background. v0.5.60/0.5.61 fix bugs and gaps found in that work.

  ## Bugs closed

  ### 1. Failed lock commands could be reported as successful
  **Bug:** `WyzeLockBoltV2`'s lock/unlock previously checked `result.code !== "1"` to detect a
  logical failure (e.g. device busy) even when the API call *resolved* rather than rejected.
  That check was dropped when the command path became fire-and-forget.
  **Why it happened:** the fire-and-forget rewrite only handled `.catch()` (network/HTTP
  errors), missing that a resolved response can still carry a failure code.
  **Fix:** the `result.code` check is restored inside `.then()`; a logical failure now clears
  the grace period immediately instead of leaving HomeKit showing a command that never applied.

  ### 2. Lock fast-polling could be silently disabled
  **Bug:** `refreshLockDevices` skipped polling if a full refresh ran within
  `securityRefreshInterval` — but that's the *same* value driving the fast poll's own tick rate.
  Any config with `refreshInterval <= securityRefreshInterval` made the skip condition true on
  almost every tick, defeating fast-polling entirely with no error or log.
  **Why it happened:** one interval value was reused for two unrelated purposes (poll cadence
  vs. "don't double-poll right after a refresh").
  **Fix:** the skip window is now a fixed 10s constant, independent of user-configured intervals.

  ### 3. HMS security panel could flicker back to "Off" mid-arm
  **Bug:** unlike locks, `WyzeHMS`'s optimistic arm/disarm had no grace period. If a full
  refresh landed while Wyze's backend still reported `"changing"`, the panel reverted to Off
  mid-command — the exact bug the grace period was built to prevent, just not applied here.
  **Fix:** HMS now uses the same grace-period mechanism as locks.

  ### 4. Plug/light/mesh-light on/off could flicker the same way
  **Bug:** same root cause as #3 — the on/off change-detection guard added in v0.5.59 has no
  grace-period equivalent, so a poll landing before Wyze's backend flips state reverts the tile.
  **Fix:** grace-period protection extended to these accessories' on/off setters.

  ### 5. Failed commands left HomeKit wrong for the full grace window
  **Bug:** across lock/HMS/plug/light/mesh-light, a rejected command promise only logged the
  error — the grace period stayed armed, so HomeKit could show incorrect state for up to 90s
  (unlock) with no correction path.
  **Fix:** command failures now clear the grace period immediately, so the *next* poll
  (seconds away) corrects the tile instead of waiting out the window.

  ### 6. Command errors were silently swallowed in plug/light/mesh-light
  **Bug:** `.catch(() => {})` on these accessories' command calls discarded errors with zero
  logging, even with `pluginLoggingEnabled` on — unlike every other accessory touched in this diff.
  **Fix:** errors are now logged consistently with the rest of the plugin.

  ### 7. `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` on Node 24.18.0+ (#307)
  **Bug:** requests to `api.wyzecam.com` and `yd-saas-toc.wyzecam.com` (the lock control/info
  host) fail with a TLS cert error.
  **Why it happened:** confirmed by direct reproduction — Node v24.18.0's NSS 3.123.1 update
  dropped the legacy "DigiCert Global Root CA" that those two hosts' certificate chains depend
  on (other Wyze hosts use a different, still-trusted root, which is why only some endpoints
  failed).
  **Fix:** `wyze-api` now pins that root explicitly via a shared `https.Agent`, so trust no
  longer depends on the host's Node version. Bumped to `^1.1.15` here — **not yet resolvable**,
  pending that PR merging and publishing to npm.
