### PR TITLE
fix(tls): default /app API to app.wyzecam.com (G2 root)

### DIFF
--- a/src/WyzeSmartHome.js
+++ b/src/WyzeSmartHome.js
@@ -66,7 +66,12 @@ module.exports = class WyzeSmartHome {
       persistPath: homebridge.user.persistPath(),
       //URLs
       authBaseUrl: this.config.authBaseUrl,
-      apiBaseUrl: this.config.apiBaseUrl,
+      // Default the /app API to app.wyzecam.com (DigiCert Global Root G2) instead of the
+      // wyze-api default api.wyzecam.com (legacy DigiCert Global Root G1). Node 24.18.0+
+      // dropped the G1 root from its bundled trust store, breaking get_object_list with
+      // UNABLE_TO_GET_ISSUER_CERT_LOCALLY. app.wyzecam.com serves the same API over a G2
+      // chain that Node still trusts. Still overridable via config.apiBaseUrl.
+      apiBaseUrl: this.config.apiBaseUrl || 'https://app.wyzecam.com',
       // App emulation constants
       authApiKey: this.config.authApiKey,
       phoneId: this.config.phoneId,


### PR DESCRIPTION
## Problem

`api.wyzecam.com` presents its TLS chain off the legacy **DigiCert Global Root CA (G1)**. Node.js **v24.18.0+** refreshed its bundled CA store (NSS 3.123.1) and dropped that G1 root, so the main refresh call fails:

```
[Wyze API] [ERROR] Request Failed: {"url":"app/v2/home_page/get_object_list","message":"unable to get local issuer certificate"}
```

Tracked in #307. The community workaround has been pinning Node to 24.17.0 / 22.x, which just avoids the affected versions indefinitely.

## Fix

Route the `/app` API through **`app.wyzecam.com`**, which serves the **same** API over a **DigiCert Global Root G2** chain that Node still trusts.

`src/WyzeSmartHome.js` now defaults `apiBaseUrl` to `https://app.wyzecam.com` when the user hasn't set one, leaving `config.apiBaseUrl` as an override. `authBaseUrl` is unchanged (`auth-prod.api.wyze.com` is already on a G2 chain).

## Verification

```
app.wyzecam.com  chain: *.wyzecam.com -> DigiCert Global G2 TLS RSA SHA256 2020 CA1 -> DigiCert Global Root G2
api.wyzecam.com  chain: *.wyzecam.com -> DigiCert TLS RSA SHA256 2020 CA1        -> DigiCert Global Root CA (G1)

POST /app/v2/home_page/get_object_list:
  app.wyzecam.com -> 200
  api.wyzecam.com -> 200   (identical API surface)
```

Client-side workaround (server-side cert migration risks deployed device firmware), mirroring SecKatie/wyzeapy#296. Endpoints with no G2 alternative (`yd-saas-toc.wyzecam.com`, `wyze-earth-service.wyzecam.com`) are hardcoded in `wyze-api` and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)