### PR TITLE
Merge main into 2.0.0: port 0.5.x hardening onto the beta branch

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,122 @@
+# Stable npm release: publishes to the `latest` tag.
+#
+# Trigger: GitHub release published WITHOUT the "Pre-release" checkbox.
+# Beta releases (checkbox checked) are handled by npm-publish-beta.yml.
+#
+# Bridge-specific: before publish, the workflow reads the wyze-api
+# submodule's package.json version and rewrites our top-level
+# `dependencies.wyze-api` to match. Edit happens only in the runner —
+# never committed back to the repo. Result: the published tarball
+# always pins the same wyze-api version that was committed in the
+# submodule pointer at release time.
+#
+# Safeguards:
+#   * Version in package.json must NOT contain `-beta.`
+#   * Version must not already be on npm
+#   * NPM_TOKEN secret must be present and valid
+#   * Submodule must be checked out — workflow exits early if missing
+
+name: npm publish (stable)
+
+on:
+  workflow_dispatch: {}
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+      apiVersion: ${{ steps.api.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Read package version
+        id: read
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Refuse beta version on stable workflow
+        run: |
+          VERSION="${{ steps.read.outputs.version }}"
+          if [[ "$VERSION" == *-beta.* ]] || [[ "$VERSION" == *-alpha.* ]] || [[ "$VERSION" == *-rc.* ]]; then
+            echo "Version $VERSION is a pre-release identifier but the GitHub release is marked stable."
+            echo "Either uncheck the 'Pre-release' box in the GitHub release UI, or rename the package.json version to a stable identifier."
+            exit 1
+          fi
+      - name: Verify submodule is present
+        run: |
+          if [ ! -f src/wyze-api/package.json ]; then
+            echo "src/wyze-api/package.json not found. The wyze-api submodule must be checked out for the version-pin step."
+            exit 1
+          fi
+      - name: Read submodule wyze-api version
+        id: api
+        run: echo "version=$(node -p "require('./src/wyze-api/package.json').version")" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          always-auth: true
+      - name: Pin wyze-api dep to submodule version
+        # Rewrites dependencies.wyze-api in package.json (runner-only — not
+        # committed). Ensures the published tarball pins exactly the api
+        # version that was committed in the submodule pointer at release.
+        run: |
+          API_VERSION="${{ needs.guard.outputs.apiVersion }}"
+          node -e "
+            const fs = require('fs');
+            const pj = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            const old = pj.dependencies['wyze-api'];
+            pj.dependencies['wyze-api'] = '$API_VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pj, null, 2) + '\n');
+            console.log('Pinned wyze-api: ' + old + ' → ' + '$API_VERSION');
+          "
+      - run: npm install --package-lock-only
+      - run: npm ci
+      - name: Verify the pinned wyze-api version exists on npm
+        run: |
+          API_VERSION="${{ needs.guard.outputs.apiVersion }}"
+          if ! npm view "wyze-api@$API_VERSION" version >/dev/null 2>&1; then
+            echo "wyze-api@$API_VERSION is not published to npm yet."
+            echo "Publish the wyze-api submodule first, then re-run this workflow."
+            exit 1
+          fi
+      - name: Ensure NPM_TOKEN is configured
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret is missing."
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Validate npm auth
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Validate bridge version is unpublished
+        run: |
+          VERSION="${{ needs.guard.outputs.version }}"
+          if npm view "homebridge-wyze-smart-home@$VERSION" version >/dev/null 2>&1; then
+            echo "Version $VERSION is already published to npm. Bump package.json version first."
+            exit 1
+          fi
+          echo "Publishing homebridge-wyze-smart-home@$VERSION to latest"
+      - run: npm publish --access public --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ homebridge.log
 config.json.old
 
 # Claude Code worktree state
-.claude/
+/.claude

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+# Dev-only submodule — release uses the wyze-api npm package instead
+src/wyze-api/
+
+# CI/CD and editor config
+.github/
+.claude/
+.vscode/
+.gitmodules
+.gitattributes
+
+# Misc
+.DS_Store
+yarn.lock
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ After you have done that if you feel like my work has been valuable to you I wel
 
 ## Releases
 
+### v2.0.0-beta.2
+
+Merges `main`'s unreleased 0.5.x hardening work (24 commits since the branches last synced at `412b891`) into the 2.0.0 line. Manual reconciliation across 18 conflicting files, not a mechanical merge — `main` and `2.0.0` had independently built overlapping features (most notably two separate Lock Bolt V2/Palm Lock implementations and two separate Thermostat fan/emheat/hold/kidlock implementations) that needed combining rather than picking one side.
+
+- **Optimistic non-blocking setters + command grace periods** ported to `WyzePlug`, `WyzeLight`, `WyzeMeshLight`, `WyzeSwitch`, `WyzeHMS`, `WyzeLock`, and `WyzeLockBoltV2` — previously only locks had this on the 2.0.0 line. A Set now updates HomeKit immediately and fires the API call in the background, with a grace window (differentiated 15s lock / 90s unlock) so a poll landing before Wyze's API propagates the change doesn't revert the optimistic state.
+- `WyzeLockBoltV2` gained `main`'s `ChargingState`/firmware-version reporting and fast IoT3 `iot-device::iot-state` offline detection, layered onto 2.0.0's persistence/`StatusFault` architecture.
+- `WyzeThermostat` gained `main`'s fan mode / emergency heat / hold / keypad-lock / scenario switches, rewritten against 2.0.0's delegated `wyze-api` conversion helpers instead of `main`'s local `colorsys`-era ones.
+- `ModelNames` lookup table and standardized log prefixes across all accessories.
+- Log-noise reduction and an accessory-routing fix (2.0.0's dispatch logic was already immune to the specific bug `main` fixed, so no functional change needed there — just confirmed).
+- Several null-guard / bug fixes from `main`'s code-review passes.
+- Bumped to `v2.0.0-beta.2`.
+
 ### v2.0.0-beta.1
 
 First 2.0 beta. Available on npm via `npm install homebridge-wyze-smart-home@beta` (or homebridge-config-ui-x → "Install Beta Version"). Stable users on the default `latest` tag are unaffected. Pairs with `wyze-api@2.0.0-beta.1`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,93 @@ Other:
 - Production npm audit: 13 → 4 issues. Both criticals cleared. Remaining 4 are the `werift` WebRTC chain.
 - Two GitHub Actions workflows: `npm-publish-stable.yml` and `npm-publish-beta.yml`. Beta workflow auto-pins the `wyze-api` dep to the submodule version and verifies alignment.
 
+### v0.5.61
+Fixes for regressions and gaps found in code review of the 0.5.59/0.5.60 optimistic-update work:
+- Fix WyzeLockBoltV2 lock/unlock commands treating a resolved-but-logically-failed IoT3 response (`result.code !== "1"`) as success — this check was dropped when the command path became fire-and-forget; it's now restored and clears the grace period on failure so HomeKit doesn't keep showing a command that never applied
+- Fix `refreshLockDevices` reusing `securityRefreshInterval` as both the fast-poll's own cadence and the "skip right after a full refresh" threshold — any config where `refreshInterval` <= `securityRefreshInterval` silently disabled lock fast-polling almost entirely; the skip window is now a fixed 10s constant, decoupled from user-configured intervals
+- Add the same optimistic-update grace period used by locks to WyzeHMS (security panel) and to the on/off setter in WyzePlug/WyzeLight/WyzeMeshLight — without it, a poll landing mid-command could revert the optimistic state back to a stale/transitional value, reproducing the exact flicker bug the grace period was built to fix for locks
+- Add a shared `armCommandGrace`/`clearCommandGrace`/`inCommandGrace` helper on the `WyzeAccessory` base class instead of copy-pasting the grace-period pattern into each accessory
+- On command failure (reject or logical failure), clear the grace period immediately across WyzeLock, WyzeLockBoltV2, WyzeHMS, WyzePlug, WyzeLight, and WyzeMeshLight so the next poll can correct the optimistic state right away instead of waiting out the full 15s/90s window
+- Fix WyzePlug/WyzeLight/WyzeMeshLight command errors being swallowed with `.catch(() => {})` and zero logging — errors are now logged when `pluginLoggingEnabled` is set, consistent with every other accessory
+- Known limitation (not changed): the grace period can still mask a genuine physical/keypad lock change or a third-party app change that happens to match the pre-command state, for the duration of the window — this is an inherent trade-off of optimistic updates and isn't fixable without the Wyze API surfacing a freshness/version signal
+- Reviewed but not changed: WyzeSwitch's `handleOnSetWallSwitch` has no grace period, so a failed command already self-corrects on the next full refresh (unlike the accessories above); the only gap is the removed `throw`, which is intentional per v0.5.59 (avoids putting the tile in a HAP error state)
+- Reviewed but not changed: `runLockFastPollLoop`'s pre-existing `securityRefreshInterval || DEFAULT_SECURITY_REFRESH_INTERVAL` treats an explicit `0` as unset; this predates this diff and is left as-is
+
+### v0.5.60
+- Differentiate command grace period by direction: locking still uses a 15s grace window, but unlocking now uses 90s to match how long the Wyze API actually takes to propagate an unlock, preventing the fast poll from reverting the optimistic "unlocked" tile back to "locked" for WyzeLock and WyzeLockBoltV2
+- Fix WyzeLock/WyzeLockBoltV2 `setLockTargetState` not updating `LockTargetState` alongside `LockCurrentState` on optimistic command updates
+- Gate new lock timing/command-ack debug logs behind `pluginLoggingEnabled`, consistent with the rest of the plugin
+
+### v0.5.59
+- Eliminate "waiting" tile state on lock/unlock commands: `setLockTargetState` now updates HomeKit optimistically and fires the API call in the background for both WyzeLockBoltV2 (Palm Lock, Lock Bolt V2) and WyzeLock (YD.LO1)
+- Add 15s command grace period on both lock types: fast poll skips updating lock state from the API during the grace window, preventing stale reads from reverting the optimistic HomeKit state before the Wyze API propagates
+- Skip fast poll when a full refresh ran within the last 10s — prevents redundant back-to-back API polls and double full refreshes after a fast-poll-detected change
+- Fix WyzeLock `updateCharacteristics` not pushing `LockTargetState` on physical lock/unlock — previously only `LockCurrentState` was updated, leaving HomeKit stuck in "waiting" after panel or physical state changes
+- Fix WyzeHMS security panel "waiting": `handleSecuritySystemTargetStateSet` now updates `SecuritySystemCurrentState` optimistically and fires `setHMSState` in the background
+- Optimistic on/off updates for WyzePlug, WyzeLight, WyzeMeshLight, and WyzeSwitch: setters update local state immediately and fire API calls in the background, eliminating HAP blocking
+- Add change detection to WyzePlug, WyzeLight, and WyzeMeshLight `updateCharacteristics`: on/off state is only pushed to HomeKit when it differs from local state, preventing 60s refresh from flickering tiles whose state was just set
+- WyzeSwitch: remove `throw` from `handleOnSetWallSwitch` error path — re-throwing caused HAP to put the tile in an error state; errors are now logged only
+- Add dev-only startup log line showing plugin version when running from a local git clone
+
+### v0.5.58
+- Fix original Wyze Lock (YD.LO1) failing with `PARAM_SIGN_INVALID` / `PARAM_TIMESTAMP_INVALID` — bumps `wyze-api` to `1.1.14`, which corrects Ford API payload signing: signature is now computed after `access_token`, `key`, and `timestamp` are injected, and `getLockInfo` now sends signed parameters on the GET request. Lock Bolt V2, Lock Bolt Pro, and Palm Lock (IoT3 path) are unaffected.
+- Closes #300
+
+### v0.5.57
+- Add `ModelNames` lookup table for cleaner device identification across all accessories
+- Standardize log prefixes across all accessories for consistent log formatting
+- Update README device list and add CONTRIBUTORS.md
+
+### v0.5.56
+- Remove `homebridge-config-ui-x` from plugin dependencies — it was never imported and caused install failures on Node.js 22/24 due to `node-pty` native bindings. Closes #286
+- Reduce log noise: apply change-detection to all accessories so HomeKit characteristics are only updated when values actually change, eliminating redundant `[Wyze]` log lines on every poll
+- Fix accessory routing regression — accessories were dispatching to the wrong handler after the 0.5.55 refactor
+- Normalize all `noResponse` log messages to a consistent format across all accessories
+- Fix four bugs identified in code review (null guards, incorrect characteristic references)
+- Homebridge 1.x and 2.x compatibility verified
+
+### v0.5.55
+- Fix continuous Homebridge restart loop introduced in 0.5.54 — closes #295
+- Add null guards for API responses across WyzeCamera, WyzeLight, WyzeMeshLight, WyzeLock, WyzeHMS, and WyzeThermostat to prevent `TypeError` crashes on transient Wyze API errors
+- Wrap all `updateCharacteristics()` calls with `Promise.resolve().catch()` to prevent unhandled rejections from terminating the Homebridge process on Node.js 15+
+- Add `default` branch to HMS state conversion to prevent undefined return
+
+### v0.5.54
+- Add Node.js 22 and 24 to supported engines — closes #281
+- Pin `eslint` to v8 to satisfy `eslint-config-standard@17` peer dependency
+- Bump `@typescript-eslint` to v8 for ESLint 9 compatibility
+
+### v0.5.53
+- First npm-published release via automated workflow
+- Add Wyze Lock Bolt v2 (`DX_LB2`) support via IoT3 API — closes #285
+- Add Palm Lock (`DX_PVLOC`) support via IoT3 API
+- Add security fast-poll loop (10s) for locks — lock state changes reflect in HomeKit within 10 seconds
+- Add `ChargingState` characteristic and firmware revision reporting to Lock Bolt V2
+- Add live connectivity detection via `iot-state` in Lock Bolt V2
+- Add humidity sensor, fan mode switch, emergency heat switch, hold mode switch, and keypad lock switch to thermostat
+- Fix thermostat sub-services resolving to the same cached service on restart
+- Fix WyzeHMS crash on offline
+- Update `wyze-api` to 1.1.12
+
+### v0.5.48
+- Add security fast-poll loop (10s) for locks — lock state changes now reflect in HomeKit within 10 seconds instead of 60
+- Add `lastDevice` caching to `WyzeAccessory` base class to support fast-poll without a full device list refresh
+- Fix `WyzeLock` first-poll spurious full refresh by initializing state vars to `null`
+- Refactor `WyzeLockBoltV2` to delegate IoT3 calls to `wyze-api` client (removes inline axios/crypto code)
+- Add `ChargingState` characteristic to `WyzeLockBoltV2` battery service (`battery::power-source` confirmed as integer: 1=battery, 2=USB)
+- Add firmware revision reporting to `WyzeLockBoltV2` via `device-info::firmware-ver`
+- Add live connectivity detection via `iot-device::iot-state` in `WyzeLockBoltV2` (faster offline detection than `conn_state`)
+- Add humidity sensor service to thermostat (surfaces `humidity` prop as `HumiditySensor`)
+- Add fan mode switch to thermostat (on = continuous fan, off = auto)
+- Add emergency heat switch to thermostat
+- Add hold mode switch to thermostat
+- Add keypad lock switch to thermostat
+- Add read-only current scenario indicator to thermostat (reflects active schedule, snaps back if toggled)
+- Fix thermostat Switch services to use `getServiceById` — prevents all sub-services resolving to the same cached service on restart
+- Fix WyzeHMS crash on offline — `this.getCharacteristic` corrected to `this.securityService.getCharacteristic`
+- Update wyze-api to 1.1.12 — includes bug fixes, lazy-load camera streaming, and removed moment dependency; if upgrading manually, run `npm install` or reinstall via the Homebridge UI to ensure the package is updated
+- Remove unused dependencies: `moment`, `inherits`, `md5`, `uuid`; revert `homebridge-config-ui-x` to `^4.56.4`
+
 ### v0.5.47
 - Add Wyze Lock Bolt v2 (DX_LB2) support via IoT3 API
 - Add Palm Lock (DX_PVLOC) support via IoT3 API

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,24 @@
+# Contributors
+
+Thanks to everyone who has contributed to this project.
+
+## Current Project (homebridge-wyze-smart-home)
+
+- [jfarmer08](https://github.com/jfarmer08) — Project maintainer
+- [carTloyal123](https://github.com/carTloyal123) — Carson Loyal
+- [identd113](https://github.com/identd113)
+- [zswuwing](https://github.com/zswuwing)
+- [Tyler Matthews](https://github.com/tmatthews)
+- [DiscoveryOV](https://github.com/DiscoveryOV)
+- [Myles Shannon](https://github.com/mylesshannon)
+- [Jake Spracher](https://github.com/jakespracher)
+- [Ritwik Gupta](https://github.com/RitwikGupta)
+- [mrlt8](https://github.com/mrlt8)
+- [kailiu](https://github.com/kailiu)
+- [Jacob Hochendoner](https://github.com/jhochendoner)
+- [Daniel Riggins](https://github.com/danielriggins)
+
+## Original Project (homebridge-wyze-connected-home)
+
+This project is a fork of [misenhower/homebridge-wyze-connected-home](https://github.com/misenhower/homebridge-wyze-connected-home).
+Thanks to [misenhower](https://github.com/misenhower) and all contributors and developers from that project.

--- a/README.md
+++ b/README.md
@@ -17,20 +17,39 @@ If you like what I have done here and want to help I would recommend that you fi
 After you have done that if you feel like my work has been valuable to you I welcome your support through Paypal, Venmo or Cash App.
 
 ## Supported Devices
-- Light Bulb
-- Light Strips
-- Color Bulb (Mesh Light)
+- Light Bulb (White, White V2)
+- Light Strips (Light Strip, Light Strip Pro)
+- Color Bulb (Mesh Light A19, BR30, A19 v2)
 - Plug
 - Outdoor Plug
 - V1 & V2 Contact Sensor (Status / Battery)
 - V1 & V2 Motion Sensor (Status / Battery)
-- Tempeature Sensor (Status / Battery)
+- Temperature & Humidity Sensor (Status / Battery)
 - Leak Sensor (Status / Battery)
 - Lock (Battery / Door Status / Control)
-- Camera v2, v3, Outdoor Cam, PamCam (on/off, Siren, Floodlight, Garage Door)
+- Lock Bolt v2 / Palm Lock (Battery / Door Status / Control)
+- Camera v1, v2, v3, v3 Pro, v4 (on/off, Siren, Floodlight, Garage Door)
+- Cam Pan, Pan v2, Pan v3 (on/off, Siren)
+- Outdoor Cam, Outdoor Cam 2
 - Wall Switch
-- HMS
+- Home Monitoring System (HMS)
 - Thermostat
+
+## Not Yet Supported
+The following Wyze products are recognized by the plugin but have no HomeKit support yet:
+- Cameras: Battery Cam Pro, Cam OG, Cam OG Telephoto 3x, Cam Floodlight Pro, Cam Pan Pro
+- Doorbells: Video Doorbell, Video Doorbell Pro, Video Doorbell Pro 2
+- Plugs: Outdoor Plug (main unit)
+- Sensors: Chime Sensor, Room Sensor (thermostat companion), Keypad
+- Locks: Lock Bolt (original BLE-only version)
+- Sprinkler Controller
+
+The following newer Wyze products have no model codes in the plugin yet:
+- Cam Pan v4, Bulb Cam, Window Cam, Battery Video Doorbell, Duo Cam Doorbell
+- Lamp Socket / Lamp Socket v2, Night Light, Surge Protector
+
+The following Wyze products are not applicable to HomeKit:
+- Robot Vacuum, Cordless Vacuum, Scales, Watch, Headphones, Air Purifier
 
 For more information about our version updates, please check our [change log](CHANGELOG.md).
 
@@ -48,13 +67,17 @@ Use the settings UI in Homebridge Config UI X to configure your Wyze account, or
       "password": "YOUR_PASSWORD",
       "keyId": "",
       "apiKey": "",
+      "hms": false,
       "lowBatteryPercentage": 30,
       "filterDeviceTypeList": ["OutdoorPlug","Plug"],
       "filterByMacAddressList": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
       "garageDoorAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
       "spotLightAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
-      "alarmAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
-      "notificationAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"]}
+      "floodLightAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
+      "sirenAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
+      "notificationAccessory": ["MAC_ADDRESS_1","MAC_ADDRESS_2"],
+      "securityRefreshInterval": 10000
+    }
   ]
 }
 ```
@@ -76,6 +99,7 @@ Once you have the API key, you can use it in your script to get the access token
 
 ### Optional Fields
 
+* **`hms`** &ndash; Set to `true` to enable the Home Monitoring System (HMS) gateway accessory. Defaults to `false`.
 * **`refreshInterval`** &ndash; Defines how often the status of the devices will be polled in milliseconds (e.g., `"refreshInterval": 60000` will check the status of your devices' status every 60 seconds). Defaults to 60 seconds.
 * **`phoneId`** &ndash; The phone id used by the Wyze App. This value is just found by intercepting your phone's traffic. If no `phoneId` is specified, a default value will be used.
 * **`logLevel`** &ndash; If no `logLevel` is specified, a default value will be used.
@@ -90,6 +114,8 @@ Once you have the API key, you can use it in your script to get the access token
 * **`persistPath`** &ndash; If no `persistPath` is specified, a default value will be used.
 * **`refreshTokenTimerEnabled`** &ndash; If no `refreshTokenTimerEnabled` is specified, a default value will be used.
 * **`lowBatteryPercentage`** &ndash; Defines when to show devices with low battery (e.g., `"lowBatteryPercentage": 30`). Defaults to 30%.
+* **`securityRefreshInterval`** &ndash; How often (in milliseconds) to fast-poll lock devices (Wyze Lock, Lock Bolt v2, Palm Lock) for state changes independently of the main refresh cycle (e.g., `"securityRefreshInterval": 10000`). Defaults to 10 seconds.
+* **`pluginLoggingEnabled`** &ndash; Enables additional plugin-level debug logging, including lock fast-poll summaries. Defaults to false.
 
 ## Other Info
 
@@ -98,6 +124,6 @@ Special thanks to the following projects for reference and inspiration:
 - [ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi), a Wyze integration for Home Assistant.
 - [wyze-node](https://github.com/noelportugal/wyze-node), a Node library for the Wyze API.
 
-Thanks to [misenhower](https://github.com/misenhower/homebridge-wyze-connected-home) for the original Wyze Homebridge plugin, and thanks to [contributors](https://github.com/misenhower/homebridge-wyze-connected-home/graphs/contributors) and [other developers who were not merged](https://github.com/misenhower/homebridge-wyze-connected-home/pulls) for volunteering their time to help fix bugs and add support for more devices and features.
+Thanks to [misenhower](https://github.com/misenhower/homebridge-wyze-connected-home) for the original Wyze Homebridge plugin, and thanks to all [contributors](CONTRIBUTORS.md) who have volunteered their time to help fix bugs and add support for more devices and features.
 
 This plugin is an actively maintained fork of misenhower's original [Wyze Homebridge Plugin](https://github.com/misenhower/homebridge-wyze-connected-home) project.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": "^18.20.4 || ^20.15.1 || ^22.0.0 || ^24"
   },
   "dependencies": {
-    "axios": "^1.12.0",
+    "axios": "^1.15.0",
     "ffmpeg-static": "^5.3.0",
     "querystring": "0.2.1",
     "utf8": "^3.0.0",
@@ -41,11 +41,11 @@
   },
   "devDependencies": {
     "@fastify/multipart": "^10.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.27.1",
-    "@typescript-eslint/parser": "^5.27.1",
-    "eslint": "^8.17.0",
-    "eslint-config-standard": "^17.0.0",
-    "homebridge": "^1.11.4",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-standard": "^17.1.0",
+    "homebridge": "^2.0.0",
     "homebridge-config-ui-x": "^5.22.0"
   },
   "funding": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-smart-home",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Wyze Smart Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/WyzeSmartHome.js
+++ b/src/WyzeSmartHome.js
@@ -1,3 +1,5 @@
+const fs = require('fs')
+const path = require('path')
 const { homebridge, Accessory, UUIDGen, Categories } = require('./types')
 const enums = require('./enums')
 const { OutdoorPlugModels, PlugModels, CommonModels, CameraModels, LeakSensorModels,
@@ -35,6 +37,19 @@ const PLUGIN_NAME = 'homebridge-wyze-smart-home'
 const PLATFORM_NAME = 'WyzeSmartHome'
 
 const DEFAULT_REFRESH_INTERVAL = 30000
+const DEFAULT_SECURITY_REFRESH_INTERVAL = 10000
+
+// Fixed window (independent of user-configured refresh intervals) used to skip
+// a fast poll immediately after a full refresh — avoids a redundant back-to-back
+// API call. Deliberately NOT tied to securityRefreshInterval: that value is also
+// the fast poll's own tick cadence, so reusing it here could make the skip
+// window as long as (or longer than) the poll loop itself and silently disable
+// fast polling whenever refreshInterval <= securityRefreshInterval.
+const FULL_REFRESH_SKIP_WINDOW_MS = 10000
+
+// Accessories that make their own API call in updateCharacteristics and return
+// a boolean indicating whether state changed — safe to fast-poll independently.
+const FAST_POLL_CLASSES = new Set([WyzeLock, WyzeLockBoltV2])
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -109,6 +124,9 @@ module.exports = class WyzeSmartHome {
     this.client = this.getClient()
 
     this.accessories = []
+    this._fastPollStats = new Map()
+    this._knownUnsupported = new Set()
+    this._lastFullRefreshAt = 0
 
     process.on('unhandledRejection', (reason) => {
       this.log.error(`Unhandled promise rejection: ${reason?.stack ?? reason}`)
@@ -163,7 +181,12 @@ module.exports = class WyzeSmartHome {
   }
 
   didFinishLaunching() {
+    if (fs.existsSync(path.join(__dirname, '..', '.git'))) {
+      const { version } = require('../package.json')
+      this.log(`[Plugin] Local dev build v${version}`)
+    }
     this.runLoop()
+    this.runLockFastPollLoop()
   }
 
   async runLoop() {
@@ -172,14 +195,64 @@ module.exports = class WyzeSmartHome {
     while (true) {
       try {
         await this.refreshDevices()
-      } catch (e) { }
+      } catch (e) {
+        this.log.error(`[Plugin] Refresh failed: ${e}`)
+      }
 
       await delay(interval)
     }
   }
 
+  async runLockFastPollLoop() {
+    const interval = this.config.securityRefreshInterval || DEFAULT_SECURITY_REFRESH_INTERVAL
+    await delay(interval)
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      try {
+        await this.refreshLockDevices()
+      } catch (e) { }
+      await delay(interval)
+    }
+  }
+
+  async refreshLockDevices() {
+    if (Date.now() - this._lastFullRefreshAt < FULL_REFRESH_SKIP_WINDOW_MS) return
+
+    const targets = this.accessories.filter(a => FAST_POLL_CLASSES.has(a.constructor) && a.lastDevice)
+    if (targets.length === 0) return
+
+    let changedDevices = []
+    for (const accessory of targets) {
+      const mac = accessory.mac
+      if (!this._fastPollStats.has(mac)) {
+        this._fastPollStats.set(mac, { name: accessory.display_name, model: accessory.model_name, attempts: 0, successes: 0, since: new Date() })
+      }
+      const stats = this._fastPollStats.get(mac)
+      stats.attempts++
+      try {
+        const changed = await accessory.updateCharacteristics(accessory.lastDevice)
+        stats.successes++
+        if (changed) changedDevices.push(`${accessory.display_name} [${accessory.model_name}]`)
+      } catch (e) { }
+    }
+
+    if (changedDevices.length > 0) {
+      if (this.config.pluginLoggingEnabled)
+        this.log(`[LockFastPoll] State change detected for ${changedDevices.join(', ')}, triggering full refresh`)
+      await this.refreshDevices()
+    }
+  }
+
   async refreshDevices() {
-    if (this.config.pluginLoggingEnabled) this.log('Refreshing devices...')
+    let fastPollSummary = ''
+    if (this._fastPollStats.size > 0) {
+      const parts = []
+      for (const [, stats] of this._fastPollStats) {
+        parts.push(`${stats.name} [${stats.model}]: ${stats.successes}/${stats.attempts} fast polls`)
+      }
+      fastPollSummary = ` (${parts.join(', ')})`
+    }
+    this._fastPollStats = new Map()
 
     try {
       const objectList = await this.client.getObjectList()
@@ -205,6 +278,8 @@ module.exports = class WyzeSmartHome {
       }
 
       await this.loadDevices(devices, timestamp)
+      this._lastFullRefreshAt = Date.now()
+      if (this.config.pluginLoggingEnabled) this.log(`Refreshed ${this.accessories.length}/${devices.length} devices${fastPollSummary}`)
     } catch (e) {
       this.log.error(`Error getting devices: ${e}`)
       throw e
@@ -370,7 +445,10 @@ module.exports = class WyzeSmartHome {
   async loadDevice(device, timestamp) {
     const accessoryClass = this.getAccessoryClass(device.product_type, device.product_model, device.mac, device.nickname)
     if (!accessoryClass) {
-      if (this.config.pluginLoggingEnabled) this.log(`[${device.product_type}] Unsupported device type: (Name: ${device.nickname}) (MAC: ${device.mac}) (Model: ${device.product_model})`)
+      if (this.config.pluginLoggingEnabled && !this._knownUnsupported.has(device.mac)) {
+        this._knownUnsupported.add(device.mac)
+        this.log(`[${device.product_type}] Unsupported device type: (Name: ${device.nickname}) (MAC: ${device.mac}) (Model: ${device.product_model})`)
+      }
       return
     }
     else if (this.config.filterByMacAddressList?.find(d => d === device.mac) || this.config.filterDeviceTypeList?.find(d => d === device.product_type)) {
@@ -400,8 +478,6 @@ module.exports = class WyzeSmartHome {
         this.api.publishExternalAccessories(PLUGIN_NAME, [homeKitAccessory])
       }
       this.accessories.push(accessory)
-    } else {
-      if (this.config.pluginLoggingEnabled) this.log(`[${device.product_type}] Loading accessory from cache ${device.nickname} (MAC: ${device.mac})`)
     }
     accessory.update(device, timestamp).catch((err) => {
       this.log.error(`[${device.product_type}] Unhandled error updating ${device.nickname}: ${err.message}\n${err.stack}`)

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -1,4 +1,5 @@
 const { Service, Characteristic } = require("../types");
+const { ModelNames } = require("../enums");
 
 // Responses from the Wyze API can lag a little after a new value is set
 const UPDATE_THROTTLE_MS = 1000;
@@ -7,6 +8,7 @@ module.exports = class WyzeAccessory {
   constructor(plugin, homeKitAccessory) {
     this.updating = false;
     this.lastTimestamp = null;
+    this.lastDevice = null;
 
     this.plugin = plugin;
     this.homeKitAccessory = homeKitAccessory;
@@ -24,6 +26,9 @@ module.exports = class WyzeAccessory {
   }
   get product_model() {
     return this.homeKitAccessory.context.product_model;
+  }
+  get model_name() {
+    return ModelNames[this.product_model] || this.product_model;
   }
 
   /** Determines whether this accessory matches the given Wyze device */
@@ -60,12 +65,26 @@ module.exports = class WyzeAccessory {
         device.firmware_ver
       );
 
+    this.lastDevice = device;
     if (this.shouldUpdateCharacteristics(timestamp)) {
-      Promise.resolve(this.updateCharacteristics(device)).catch((err) => {
-        this.plugin.log.error(
-          `[${device.product_type}] Error updating ${device.nickname}: ${err.message}\n${err.stack}`
-        );
-      });
+      this.lastTimestamp = timestamp;
+      this.updating = true;
+      try {
+        // Promise.resolve wraps both sync-return and async-return uniformly.
+        // The outer try/catch is required: if updateCharacteristics() throws
+        // synchronously, the throw escapes Promise.resolve() before .catch()
+        // is attached, which would turn update() into an unhandled rejection.
+        Promise.resolve(this.updateCharacteristics(device))
+          .catch(e => {
+            if (this.plugin?.log?.error)
+              this.plugin.log.error(`[${this.product_type}] Error updating "${this.display_name}": ${e}`);
+          })
+          .finally(() => { this.updating = false; });
+      } catch (e) {
+        this.updating = false;
+        if (this.plugin?.log?.error)
+          this.plugin.log.error(`[${this.product_type}] Error updating "${this.display_name}": ${e}`);
+      }
     }
   }
   shouldUpdateCharacteristics(timestamp) {
@@ -131,6 +150,23 @@ module.exports = class WyzeAccessory {
   }
 
   sleep(ms) {
-    return new Promise((resolve) => setTimeout(resolve, ms * 1000));
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // Optimistic-update grace period: after firing a command, arm this for the
+  // command's expected propagation time so a poll landing before the Wyze API
+  // catches up doesn't revert the optimistic HomeKit state back to stale data.
+  armCommandGrace(ms) {
+    this._commandGraceUntil = Date.now() + ms;
+  }
+
+  // Call when a command is known to have failed so the next poll (rather than
+  // the full grace window) is free to correct the optimistic state.
+  clearCommandGrace() {
+    this._commandGraceUntil = 0;
+  }
+
+  inCommandGrace() {
+    return Date.now() <= (this._commandGraceUntil || 0);
   }
 };

--- a/src/accessories/WyzeContactSensor.js
+++ b/src/accessories/WyzeContactSensor.js
@@ -65,6 +65,7 @@ module.exports = class WyzeContactSensor extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
     // Wyze open_close_state: 0 = closed, 1 = open. HomeKit's
     // ContactSensorState happens to use the same numbers but we map

--- a/src/accessories/WyzeHMS.js
+++ b/src/accessories/WyzeHMS.js
@@ -48,14 +48,19 @@ module.exports = class WyzeHMS extends WyzeAccessory {
     try {
       await this.getHmsID();
       const response = await this.plugin.client.monitoringProfileStateStatus(this.hmsId);
-      this.hmsStatus = response.message;
-      this.securityService
-        .getCharacteristic(Characteristic.SecuritySystemCurrentState)
-        .updateValue(this.plugin.client.wyzeHmsStateToHomeKit(this.hmsStatus));
-      // Persist so HomeKit gets the right value immediately after a reboot.
-      this.persistState({ hmsStatus: this.hmsStatus, hmsId: this.hmsId });
-      if (this.plugin.config.pluginLoggingEnabled)
-        this.plugin.log(`[HMS] ${this.display_name}: ${this.hmsStatus}`);
+      // Skip during grace period after a command — the API can report a
+      // transient "changing" status while the real arm/disarm propagates,
+      // which would otherwise revert the optimistic update we just made.
+      if (!this.inCommandGrace()) {
+        this.hmsStatus = response.message;
+        this.securityService
+          .getCharacteristic(Characteristic.SecuritySystemCurrentState)
+          .updateValue(this.plugin.client.wyzeHmsStateToHomeKit(this.hmsStatus));
+        // Persist so HomeKit gets the right value immediately after a reboot.
+        this.persistState({ hmsStatus: this.hmsStatus, hmsId: this.hmsId });
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[HMS] ${this.display_name}: ${this.hmsStatus}`);
+      }
     } catch (err) {
       this.plugin.log.error(
         `[HMS] Update failed for "${this.display_name}": ${err.message || err}`
@@ -76,14 +81,26 @@ module.exports = class WyzeHMS extends WyzeAccessory {
     const wyzeState = this.plugin.client.homeKitHmsStateToWyze(value);
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(`[HMS] Set target "${this.display_name}": ${wyzeState}`);
-    try {
-      await this.plugin.client.setHMSState(this.hmsId, wyzeState);
-    } catch (err) {
-      this.plugin.log.error(
-        `[HMS] Set failed for "${this.display_name}": ${err.message || err}`
-      );
-      throw err;
-    }
+
+    // Optimistic update so the panel clears immediately. Grace period
+    // prevents the next full refresh from reverting this before the API
+    // propagates (or from re-showing a stale "changing" status).
+    this.hmsStatus = wyzeState === "off" ? "disarm" : wyzeState;
+    this.armCommandGrace(15000);
+    this.securityService
+      .getCharacteristic(Characteristic.SecuritySystemCurrentState)
+      .updateValue(this.plugin.client.wyzeHmsStateToHomeKit(this.hmsStatus));
+
+    this.getHmsID()
+      .then(() => this.plugin.client.setHMSState(this.hmsId, wyzeState))
+      .catch((err) => {
+        // Command never went through — let the next full refresh correct
+        // the optimistic state instead of holding it for the full grace window.
+        this.clearCommandGrace();
+        this.plugin.log.error(
+          `[HMS] Set failed for "${this.display_name}": ${err.message || err}`
+        );
+      });
   }
 
   async getHmsID() {

--- a/src/accessories/WyzeLeakSensor.js
+++ b/src/accessories/WyzeLeakSensor.js
@@ -65,6 +65,7 @@ module.exports = class WyzeLeakSensor extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
     // Wyze ws_detect_state: 0 = dry, 1 = wet. The helper also collapses
     // any unknown value (>= 2) to "leak detected" as a fail-safe — better

--- a/src/accessories/WyzeLight.js
+++ b/src/accessories/WyzeLight.js
@@ -7,9 +7,17 @@ module.exports = class WyzeLight extends WyzeAccessory {
   constructor(plugin, homeKitAccessory) {
     super(plugin, homeKitAccessory);
 
-    this.getCharacteristic(Characteristic.On).on("set", this.setOn.bind(this));
-    this.getCharacteristic(Characteristic.Brightness).on("set", this.setBrightness.bind(this));
-    this.getCharacteristic(Characteristic.ColorTemperature).on("set", this.setColorTemperature.bind(this));
+    this.getCharacteristic(Characteristic.On)
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
+    this.getCharacteristic(Characteristic.Brightness)
+      .onSet(this.setBrightness.bind(this));
+    this.getCharacteristic(Characteristic.ColorTemperature)
+      .onSet(this.setColorTemperature.bind(this));
+  }
+
+  async getOn() {
+    return this._switchState === 1;
   }
 
   getService() {
@@ -41,9 +49,17 @@ module.exports = class WyzeLight extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
-    const isOn = device.device_params.switch_state === 1;
-    this.getCharacteristic(Characteristic.On).updateValue(isOn);
+    // Skip pushing On from the poll while a just-issued command's grace
+    // period is active, or if it hasn't actually changed — avoids
+    // reverting the optimistic UI update before Wyze's API propagates it.
+    const switchState = device.device_params.switch_state;
+    const isOn = switchState === 1;
+    if (switchState !== this._switchState && !this.inCommandGrace()) {
+      this._switchState = switchState;
+      this.getCharacteristic(Characteristic.On).updateValue(isOn);
+    }
 
     // NOTE: this is one extra API call per light per refresh cycle (on top
     // of the bulk getObjectList). With many bulbs configured, this adds up
@@ -89,36 +105,33 @@ module.exports = class WyzeLight extends WyzeAccessory {
       );
   }
 
-  async setOn(value, callback) {
+  async setOn(value) {
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[Light] Setting power for ${this.mac} (${this.display_name}) to ${value ? "on" : "off"}`
       );
-    try {
-      await this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0");
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[Light] setOn failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    this._switchState = value ? 1 : 0;
+    this.armCommandGrace(15000);
+    this.plugin.client.lightPower(this.mac, this.product_model, value ? "1" : "0").catch((e) => {
+      this.clearCommandGrace();
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Light] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
-  async setBrightness(value, callback) {
+  async setBrightness(value) {
     await this.sleep(250);
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[Light] Setting brightness for ${this.mac} (${this.display_name}) to ${value}`
       );
-    try {
-      await this.plugin.client.setBrightness(this.mac, this.product_model, value);
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[Light] setBrightness failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    this.plugin.client.setBrightness(this.mac, this.product_model, value).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Light] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
-  async setColorTemperature(value, callback) {
+  async setColorTemperature(value) {
     await this.sleep(500);
     // homeKitColorTempToWyze stretches HomeKit's wider mireds range
     // (140–500) linearly across Wyze's narrower Kelvin range (2700–6500)
@@ -129,12 +142,9 @@ module.exports = class WyzeLight extends WyzeAccessory {
       this.plugin.log(
         `[Light] Setting color temp for ${this.mac} (${this.display_name}) to ${value} mireds (${wyzeValue}K)`
       );
-    try {
-      await this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue);
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[Light] setColorTemperature failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    this.plugin.client.setColorTemperature(this.mac, this.product_model, wyzeValue).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Light] Command error for "${this.display_name}": ${e}`);
+    });
   }
 };

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -65,7 +65,7 @@ module.exports = class WyzeLock extends WyzeAccessory {
         this.plugin.log(
           `[Lock] "${this.display_name} (${this.mac})" is offline — keeping last known state, marked with fault`
         );
-      return;
+      return false;
     }
 
     // NOTE: one extra Ford-API call per refresh (getLockInfo) on top of
@@ -78,13 +78,13 @@ module.exports = class WyzeLock extends WyzeAccessory {
         `[Lock] getLockInfo failed for "${this.display_name}": ${err.message || err}`
       );
       markServiceOnline(this.lockService, false, "fault");
-      return;
+      return false;
     }
 
     const lockProperties = propertyList?.device;
     if (!lockProperties) {
       this.plugin.log.error(`[Lock] getLockInfo returned no device data for ${this.display_name}`);
-      return;
+      return false;
     }
 
     if (lockProperties.onoff_line !== undefined) {
@@ -120,7 +120,9 @@ module.exports = class WyzeLock extends WyzeAccessory {
     // state so a physical/keypad change doesn't leave HomeKit stuck showing
     // "waiting" on the tile.
     const lockerStatus = lockProperties.locker_status || {};
+    let changed = false;
     if (lockerStatus.hardlock !== undefined && !this.inCommandGrace()) {
+      changed = this.hardlock !== lockerStatus.hardlock;
       this.hardlock = lockerStatus.hardlock;
       const lockState = this.plugin.client.getLockState(this.hardlock);
       this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(lockState);
@@ -142,6 +144,8 @@ module.exports = class WyzeLock extends WyzeAccessory {
         `[Lock] ${this.display_name}: ${this.hardlock === 2 ? "unlocked" : "locked"}, ` +
           `door ${this.door_open_status === 1 ? "open" : "closed"}, battery ${this.lockPower}%`
       );
+
+    return changed;
   }
 
   async getLockCurrentState() {

--- a/src/accessories/WyzeLock.js
+++ b/src/accessories/WyzeLock.js
@@ -113,12 +113,18 @@ module.exports = class WyzeLock extends WyzeAccessory {
       this.trash_mode = lockProperties.trash_mode;
     }
 
+    // Skip hardlock (locked/unlocked) during grace period after a command —
+    // the Ford API lags a few seconds (unlock can take ~90s) before
+    // reflecting the new state, which would otherwise revert the optimistic
+    // update setLockTargetState already made. Push both Current AND Target
+    // state so a physical/keypad change doesn't leave HomeKit stuck showing
+    // "waiting" on the tile.
     const lockerStatus = lockProperties.locker_status || {};
-    if (lockerStatus.hardlock !== undefined) {
+    if (lockerStatus.hardlock !== undefined && !this.inCommandGrace()) {
       this.hardlock = lockerStatus.hardlock;
-      this.lockService
-        .getCharacteristic(Characteristic.LockCurrentState)
-        .updateValue(this.plugin.client.getLockState(this.hardlock));
+      const lockState = this.plugin.client.getLockState(this.hardlock);
+      this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(lockState);
+      this.lockService.getCharacteristic(Characteristic.LockTargetState).updateValue(lockState);
     }
 
     // Persist so the next reboot shows real state instead of undefined
@@ -170,27 +176,36 @@ module.exports = class WyzeLock extends WyzeAccessory {
       this.plugin.log(
         `[Lock] Set "${this.display_name}": ${isSecuring ? "lock" : "unlock"}`
       );
-    try {
-      await this.plugin.client.controlLock(
-        this.mac,
-        this.product_model,
-        isSecuring ? "remoteLock" : "remoteUnlock"
-      );
-    } catch (err) {
-      this.plugin.log.error(
-        `[Lock] Set failed for "${this.display_name}": ${err.message || err}`
-      );
-      throw err;
-    }
 
-    // The Ford API doesn't immediately reflect the new state in subsequent
-    // getLockInfo calls — there's a few-second lag. Optimistically update
-    // CurrentState so HomeKit shows the new state right away. The next
-    // refresh-cycle getLockInfo will overwrite if the lock didn't actually
-    // honor the command (e.g. battery dead, mechanical jam).
-    this.lockService.setCharacteristic(
-      Characteristic.LockCurrentState,
+    // Optimistically update HomeKit immediately so the tile clears "waiting".
+    // Grace period prevents the fast poll from reverting this before the API
+    // propagates. Locking propagates in ~15s; unlocking takes ~90s on the
+    // Wyze Ford API endpoint.
+    this.hardlock = isSecuring ? 1 : 2;
+    this.armCommandGrace(isSecuring ? 15000 : 90000);
+    this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(
       isSecuring ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED
     );
+    this.lockService.getCharacteristic(Characteristic.LockTargetState).updateValue(
+      isSecuring ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED
+    );
+
+    const cmdT0 = Date.now();
+    this.plugin.client.controlLock(
+      this.mac,
+      this.product_model,
+      isSecuring ? "remoteLock" : "remoteUnlock"
+    )
+      .then(() => {
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[Lock] Command ACK in ${Date.now() - cmdT0}ms for "${this.display_name}"`);
+      })
+      .catch((e) => {
+        // Command failed — don't leave the optimistic state stuck for the
+        // full grace window; let the next poll correct it.
+        this.clearCommandGrace();
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[Lock] Command error after ${Date.now() - cmdT0}ms for "${this.display_name}": ${e}`);
+      });
   }
 };

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -13,6 +13,8 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     this.isLocked = persisted.isLocked ?? true;
     this.isDoorOpen = persisted.isDoorOpen ?? false;
     this.batteryLevel = persisted.batteryLevel ?? 100;
+    this.chargingState = persisted.chargingState ?? 0;
+    this.firmwareVersion = persisted.firmwareVersion ?? "";
 
     this.lockService = this._getOrAddService(Service.LockMechanism, "LockMechanism");
     this.contactService = this._getOrAddService(Service.ContactSensor, "Door Contact");
@@ -38,7 +40,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
       .onGet(this.getLowBatteryStatus.bind(this));
     this.batteryService
       .getCharacteristic(Characteristic.ChargingState)
-      .onGet(() => Characteristic.ChargingState.NOT_CHARGING);
+      .onGet(this.getChargingState.bind(this));
   }
 
   _getOrAddService(ServiceType, label) {
@@ -67,6 +69,10 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
 
     // NOTE: one extra IoT3 call per refresh (lockBoltV2GetProperties) on
     // top of the bulk getObjectList. Bulk list doesn't include lock state.
+    //
+    // Palm Lock (DX_PVLOC) intentionally uses lockBoltV2GetProperties too —
+    // it supports all 6 props, whereas palmLockGetProperties in wyze-api is
+    // missing door-status + power-source.
     let result;
     try {
       result = await this.plugin.client.lockBoltV2GetProperties(this.mac, this.product_model);
@@ -87,14 +93,29 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
 
     const props = result.data?.props || {};
 
+    // iot-device::iot-state reflects live connectivity — catches disconnects
+    // faster than device.conn_state which only updates on the slow poll.
+    if (props["iot-device::iot-state"] !== undefined && !props["iot-device::iot-state"]) {
+      markServiceOnline(this.lockService, false, "fault");
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(
+          `[LockBoltV2] "${this.display_name} (${this.mac})" offline per IoT3 iot-state`
+        );
+      return;
+    }
+
     if (props["lock::lock-status"] !== undefined) {
-      this.isLocked = !!props["lock::lock-status"];
-      this.lockService
-        .getCharacteristic(Characteristic.LockCurrentState)
-        .updateValue(this.isLocked ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED);
-      this.lockService
-        .getCharacteristic(Characteristic.LockTargetState)
-        .updateValue(this.isLocked ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED);
+      // Skip during grace period after a command to avoid reverting an
+      // optimistic update before the API has propagated the change.
+      if (!this.inCommandGrace()) {
+        this.isLocked = !!props["lock::lock-status"];
+        this.lockService
+          .getCharacteristic(Characteristic.LockCurrentState)
+          .updateValue(this.isLocked ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED);
+        this.lockService
+          .getCharacteristic(Characteristic.LockTargetState)
+          .updateValue(this.isLocked ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED);
+      }
     }
 
     if (props["lock::door-status"] !== undefined) {
@@ -119,11 +140,28 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         .updateValue(this.plugin.client.checkLowBattery(this.batteryLevel));
     }
 
+    if (props["battery::power-source"] !== undefined) {
+      // power-source: 1 = battery (not charging), 2 = USB/charging (inferred)
+      this.chargingState = props["battery::power-source"] === 2 ? 1 : 0;
+      this.batteryService
+        .getCharacteristic(Characteristic.ChargingState)
+        .updateValue(this.chargingState);
+    }
+
+    if (props["device-info::firmware-ver"] !== undefined) {
+      this.firmwareVersion = String(props["device-info::firmware-ver"]);
+      this.homeKitAccessory
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.FirmwareRevision, this.firmwareVersion);
+    }
+
     // Persist for next reboot.
     this.persistState({
       isLocked: this.isLocked,
       isDoorOpen: this.isDoorOpen,
       batteryLevel: this.batteryLevel,
+      chargingState: this.chargingState,
+      firmwareVersion: this.firmwareVersion,
     });
 
     if (this.plugin.config.pluginLoggingEnabled)
@@ -159,6 +197,10 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
     return this.plugin.client.checkLowBattery(this.batteryLevel);
   }
 
+  async getChargingState() {
+    return this.chargingState;
+  }
+
   async setLockTargetState(targetState) {
     const isSecuring = targetState === Characteristic.LockTargetState.SECURED;
     if (this.plugin.config.pluginLoggingEnabled)
@@ -166,27 +208,43 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         `[LockBoltV2] Set "${this.display_name} (${this.mac})": ${isSecuring ? "lock" : "unlock"}`
       );
 
-    try {
-      const result = isSecuring
-        ? await this.plugin.client.lockBoltV2Lock(this.mac, this.product_model)
-        : await this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
+    // Optimistically update HomeKit immediately so the tile clears "waiting".
+    // Grace period prevents the fast poll from reverting this before the API
+    // propagates. Locking propagates in ~15s; unlocking takes ~90s on the
+    // Wyze IoT3 endpoint.
+    this.isLocked = isSecuring;
+    this.armCommandGrace(isSecuring ? 15000 : 90000);
+    this.lockService.getCharacteristic(Characteristic.LockCurrentState).updateValue(
+      isSecuring ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED
+    );
+    this.lockService.getCharacteristic(Characteristic.LockTargetState).updateValue(
+      isSecuring ? Characteristic.LockTargetState.SECURED : Characteristic.LockTargetState.UNSECURED
+    );
 
-      if (result?.code !== "1") {
-        const msg = `IoT3 returned code ${result?.code}: ${result?.msg}`;
-        this.plugin.log.error(`[LockBoltV2] Set failed for "${this.display_name}": ${msg}`);
-        throw new Error(msg);
-      }
+    const cmdT0 = Date.now();
+    const call = isSecuring
+      ? this.plugin.client.lockBoltV2Lock(this.mac, this.product_model)
+      : this.plugin.client.lockBoltV2Unlock(this.mac, this.product_model);
 
-      this.isLocked = isSecuring;
-      this.lockService.setCharacteristic(
-        Characteristic.LockCurrentState,
-        isSecuring ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED
-      );
-    } catch (e) {
-      this.plugin.log.error(
-        `[LockBoltV2] Set failed for "${this.display_name}": ${e.message || e}`
-      );
-      throw e;
-    }
+    call
+      .then((result) => {
+        if (!result || result.code !== "1") {
+          // IoT3 resolved without throwing but reported a logical failure —
+          // don't leave HomeKit showing a command that never actually applied.
+          this.clearCommandGrace();
+          this.plugin.log.error(
+            `[LockBoltV2] Command failed for "${this.display_name}": ${result?.msg ?? "no response"}`
+          );
+          return;
+        }
+        if (this.plugin.config.pluginLoggingEnabled)
+          this.plugin.log(`[LockBoltV2] Command ACK in ${Date.now() - cmdT0}ms for "${this.display_name}"`);
+      })
+      .catch((e) => {
+        this.clearCommandGrace();
+        this.plugin.log.error(
+          `[LockBoltV2] Command error after ${Date.now() - cmdT0}ms for "${this.display_name}": ${e.message || e}`
+        );
+      });
   }
 };

--- a/src/accessories/WyzeLockBoltV2.js
+++ b/src/accessories/WyzeLockBoltV2.js
@@ -64,7 +64,7 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         this.plugin.log(
           `[LockBoltV2] "${this.display_name} (${this.mac})" is offline — keeping last known state, marked with fault`
         );
-      return;
+      return false;
     }
 
     // NOTE: one extra IoT3 call per refresh (lockBoltV2GetProperties) on
@@ -81,14 +81,14 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         `[LockBoltV2] Update failed for "${this.display_name}": ${e.message || e}`
       );
       markServiceOnline(this.lockService, false, "fault");
-      return;
+      return false;
     }
 
     if (result?.code !== "1") {
       this.plugin.log.warn?.(
         `[LockBoltV2] IoT3 returned code ${result?.code} for "${this.display_name}": ${result?.msg}`
       );
-      return;
+      return false;
     }
 
     const props = result.data?.props || {};
@@ -101,14 +101,17 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         this.plugin.log(
           `[LockBoltV2] "${this.display_name} (${this.mac})" offline per IoT3 iot-state`
         );
-      return;
+      return false;
     }
 
+    let changed = false;
     if (props["lock::lock-status"] !== undefined) {
       // Skip during grace period after a command to avoid reverting an
       // optimistic update before the API has propagated the change.
       if (!this.inCommandGrace()) {
-        this.isLocked = !!props["lock::lock-status"];
+        const newLocked = !!props["lock::lock-status"];
+        changed = this.isLocked !== newLocked;
+        this.isLocked = newLocked;
         this.lockService
           .getCharacteristic(Characteristic.LockCurrentState)
           .updateValue(this.isLocked ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED);
@@ -169,6 +172,8 @@ module.exports = class WyzeLockBoltV2 extends WyzeAccessory {
         `[LockBoltV2] ${this.display_name}: ${this.isLocked ? "locked" : "unlocked"}, ` +
           `door ${this.isDoorOpen ? "open" : "closed"}, battery ${this.batteryLevel}%`
       );
+
+    return changed;
   }
 
   async getLockCurrentState() {

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -7,11 +7,13 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
   constructor(plugin, homeKitAccessory) {
     super(plugin, homeKitAccessory);
 
-    this.getCharacteristic(Characteristic.On).on("set", this.setOn.bind(this));
-    this.getCharacteristic(Characteristic.Brightness).on("set", this.setBrightness.bind(this));
-    this.getCharacteristic(Characteristic.ColorTemperature).on("set", this.setColorTemperature.bind(this));
-    this.getCharacteristic(Characteristic.Hue).on("set", this.setHue.bind(this));
-    this.getCharacteristic(Characteristic.Saturation).on("set", this.setSaturation.bind(this));
+    this.getCharacteristic(Characteristic.On)
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
+    this.getCharacteristic(Characteristic.Brightness).onSet(this.setBrightness.bind(this));
+    this.getCharacteristic(Characteristic.ColorTemperature).onSet(this.setColorTemperature.bind(this));
+    this.getCharacteristic(Characteristic.Hue).onSet(this.setHue.bind(this));
+    this.getCharacteristic(Characteristic.Saturation).onSet(this.setSaturation.bind(this));
 
     // HomeKit fires Hue and Saturation as two independent set events but
     // Wyze only accepts a combined color value. Cache one and wait for the
@@ -46,9 +48,17 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
-    const isOn = device.device_params.switch_state === 1;
-    this.getCharacteristic(Characteristic.On).updateValue(isOn);
+    // Skip pushing On from the poll while a just-issued command's grace
+    // period is active, or if it hasn't actually changed — avoids
+    // reverting the optimistic UI update before Wyze's API propagates it.
+    const switchState = device.device_params.switch_state;
+    const isOn = switchState === 1;
+    if (switchState !== this._switchState && !this.inCommandGrace()) {
+      this._switchState = switchState;
+      this.getCharacteristic(Characteristic.On).updateValue(isOn);
+    }
 
     // NOTE: one extra getDevicePID call per bulb per refresh on top of the
     // bulk getObjectList. Brightness / color temp / color aren't returned
@@ -126,68 +136,65 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
     this.cache.saturation = saturation;
   }
 
-  async setOn(value, callback) {
+  async getOn() {
+    return this._switchState === 1;
+  }
+
+  async setOn(value) {
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[MeshLight] Set power "${this.display_name} (${this.mac})": ${value ? "on" : "off"}`
       );
-    try {
-      await this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0");
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[MeshLight] setOn failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    this._switchState = value ? 1 : 0;
+    this.armCommandGrace(15000);
+    this.plugin.client.lightMeshPower(this.mac, this.product_model, value ? "1" : "0").catch((e) => {
+      this.clearCommandGrace();
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
-  async setBrightness(value, callback) {
+  async setBrightness(value) {
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[MeshLight] Set brightness "${this.display_name} (${this.mac})": ${value}`
       );
-    try {
-      await this.plugin.client.setMeshBrightness(this.mac, this.product_model, value);
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[MeshLight] setBrightness failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    this.plugin.client.setMeshBrightness(this.mac, this.product_model, value).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
-  async setColorTemperature(value, callback) {
+  async setColorTemperature(value) {
     if (value == null) return;
     const wyzeValue = this.plugin.client.homeKitColorTempToWyze(value);
     if (this.plugin.config.pluginLoggingEnabled)
       this.plugin.log(
         `[MeshLight] Set color temp "${this.display_name} (${this.mac})": ${value} mireds → ${wyzeValue}K`
       );
-    try {
-      await this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue);
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[MeshLight] setColorTemperature failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    this.plugin.client.setMeshColorTemperature(this.mac, this.product_model, wyzeValue).catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
-  async setHue(value, callback) {
+  async setHue(value) {
     if (value == null) return;
     this.cache.hue = value;
-    await this._maybeFlushColor(callback, "hue");
+    this._maybeFlushColor("hue");
   }
 
-  async setSaturation(value, callback) {
+  async setSaturation(value) {
     if (value == null) return;
     this.cache.saturation = value;
-    await this._maybeFlushColor(callback, "saturation");
+    this._maybeFlushColor("saturation");
   }
 
   // HomeKit fires hue + saturation independently. We hold the first one in
   // cache and push to Wyze on the second so it sees a complete color update.
-  async _maybeFlushColor(callback, source) {
+  _maybeFlushColor(source) {
     if (!this.cacheUpdated) {
       this.cacheUpdated = true;
-      callback();
       return;
     }
     this.cacheUpdated = false;
@@ -196,18 +203,14 @@ module.exports = class WyzeMeshLight extends WyzeAccessory {
       this.plugin.log(
         `[MeshLight] Set color "${this.display_name} (${this.mac})": h=${this.cache.hue} s=${this.cache.saturation} → ${hexValue}`
       );
-    try {
-      // Either setMeshHue or setMeshSaturation works — they both push the
-      // combined hex color. Pick based on which event triggered the flush.
-      if (source === "hue") {
-        await this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue);
-      } else {
-        await this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue);
-      }
-      callback();
-    } catch (e) {
-      this.plugin.log.error(`[MeshLight] setColor failed for ${this.display_name}: ${e.message || e}`);
-      callback(e);
-    }
+    // Either setMeshHue or setMeshSaturation works — they both push the
+    // combined hex color. Pick based on which event triggered the flush.
+    const call = source === "hue"
+      ? this.plugin.client.setMeshHue(this.mac, this.product_model, hexValue)
+      : this.plugin.client.setMeshSaturation(this.mac, this.product_model, hexValue);
+    call.catch((e) => {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[MeshLight] Command error for "${this.display_name}": ${e}`);
+    });
   }
 };

--- a/src/accessories/WyzeMotionSensor.js
+++ b/src/accessories/WyzeMotionSensor.js
@@ -65,6 +65,7 @@ module.exports = class WyzeMotionSensor extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
     // Wyze motion_state: 0 = no motion, 1 = motion detected.
     // HomeKit MotionDetected is a boolean — coerce explicitly.

--- a/src/accessories/WyzePlug.js
+++ b/src/accessories/WyzePlug.js
@@ -11,10 +11,35 @@ module.exports = class WyzePlug extends WyzeAccessory {
     const persisted = this.loadPersistedState();
     this.outletInUse = persisted.outletInUse;
 
-    this.getOnCharacteristic().on("set", this.set.bind(this));
+    this.getOnCharacteristic()
+      .onGet(this.getOn.bind(this))
+      .onSet(this.setOn.bind(this));
     this.getOutletService()
       .getCharacteristic(Characteristic.OutletInUse)
       .onGet(this.getOutletInUse.bind(this));
+  }
+
+  async getOn() {
+    return this._switchState === 1;
+  }
+
+  async setOn(value) {
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(
+        `[Plug] Setting power for "${this.display_name} (${this.mac})" to ${value}`
+      );
+    this._switchState = value ? 1 : 0;
+    this.outletInUse = !!value;
+    this.getOutletService()
+      .getCharacteristic(Characteristic.OutletInUse)
+      .updateValue(this.outletInUse);
+    this.persistState({ outletInUse: this.outletInUse });
+    this.armCommandGrace(15000);
+    this.plugin.client.plugPower(this.mac, this.product_model, value ? "1" : "0").catch((e) => {
+      this.clearCommandGrace();
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Plug] Command error for "${this.display_name}": ${e}`);
+    });
   }
 
   getOutletService() {
@@ -48,9 +73,18 @@ module.exports = class WyzePlug extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
     // Wyze switch_state: 0 = off, 1 = on. Coerce explicitly.
-    const isOn = device.device_params.switch_state === 1;
+    // Skip while a just-issued command's grace period is active, or if
+    // the state hasn't actually changed — avoids reverting the optimistic
+    // UI update before Wyze's API has propagated the change, and avoids
+    // redundant pushes/log lines every poll.
+    const switchState = device.device_params.switch_state;
+    if (switchState === this._switchState || this.inCommandGrace()) return;
+    this._switchState = switchState;
+
+    const isOn = switchState === 1;
     this.outletInUse = isOn;
     this.getOnCharacteristic().updateValue(isOn);
     this.getOutletService()
@@ -62,25 +96,5 @@ module.exports = class WyzePlug extends WyzeAccessory {
       this.plugin.log(
         `[Plug] ${this.mac} (${this.display_name}): ${isOn ? "on" : "off"}`
       );
-  }
-
-  async set(value, callback) {
-    if (this.plugin.config.pluginLoggingEnabled)
-      this.plugin.log(
-        `[Plug] Setting power for "${this.display_name} (${this.mac})" to ${value ? "on" : "off"}`
-      );
-    try {
-      await this.plugin.client.plugPower(
-        this.mac,
-        this.product_model,
-        value ? "1" : "0"
-      );
-      callback();
-    } catch (e) {
-      this.plugin.log.error(
-        `[Plug] Set failed for "${this.display_name}": ${e.message || e}`
-      );
-      callback(e);
-    }
   }
 };

--- a/src/accessories/WyzeSwitch.js
+++ b/src/accessories/WyzeSwitch.js
@@ -125,32 +125,29 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
       this.plugin.log(
         `[Switch] Set "${this.display_name} (${this.mac})": ${value ? "on" : "off"}`
       );
-    try {
-      // Palm devices need IoT vs Classic routing; LightSwitch always uses
-      // single_press_type to decide. Both branches converge on the same
-      // two backend calls.
-      const isPalm = this.product_model === CommonModels.Palm;
-      const prefersIot = isPalm
-        ? this.single_press_type == SinglePressType.IOT || this.switch_iot !== undefined
-        : this.single_press_type == SinglePressType.IOT;
 
-      if (prefersIot) {
-        await this.plugin.client.wallSwitchIot(this.mac, this.product_model, !!value);
-      } else {
-        await this.plugin.client.wallSwitchPower(this.mac, this.product_model, !!value);
-      }
+    // Reflect the user's intent immediately — Wyze doesn't push a fast
+    // state update back through the bulk list, so waiting for the next
+    // poll would show a stale/reverted tile until the next refresh.
+    this.switch_power = !!value;
+    this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
 
-      if (isPalm) {
-        // Palm doesn't push a state update back through the bulk list right
-        // away, so reflect the user's intent immediately on the local cache.
-        this.switch_power = !!value;
-        this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
-      }
-    } catch (error) {
+    // Palm devices need IoT vs Classic routing; LightSwitch always uses
+    // single_press_type to decide. Both branches converge on the same
+    // two backend calls.
+    const isPalm = this.product_model === CommonModels.Palm;
+    const prefersIot = isPalm
+      ? this.single_press_type == SinglePressType.IOT || this.switch_iot !== undefined
+      : this.single_press_type == SinglePressType.IOT;
+
+    const call = prefersIot
+      ? this.plugin.client.wallSwitchIot(this.mac, this.product_model, !!value)
+      : this.plugin.client.wallSwitchPower(this.mac, this.product_model, !!value);
+
+    call.catch((error) => {
       this.plugin.log.error?.(
         `[Switch] Set failed for "${this.display_name} (${this.mac})": ${error.message || error}`
       );
-      throw error;
-    }
+    });
   }
 };

--- a/src/accessories/WyzeSwitch.js
+++ b/src/accessories/WyzeSwitch.js
@@ -84,18 +84,7 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
           this.switch_power = !!value;
           this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
           break;
-        case "palm-state":
-          // Palm reports as boolean or 0/1 for power; default to false for safety.
-          this.switch_power = value == null ? false : !!value;
-          this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
-          break;
       }
-    }
-
-    // Palm devices that haven't reported a switch_power yet — assume off.
-    if (this.product_model === CommonModels.Palm && this.switch_power === undefined) {
-      this.switch_power = false;
-      this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(false);
     }
 
     // Persist so HomeKit gets the right value immediately after a reboot
@@ -132,13 +121,7 @@ module.exports = class WyzeSwitch extends WyzeAccessory {
     this.switch_power = !!value;
     this.wallSwitch.getCharacteristic(Characteristic.On).updateValue(this.switch_power);
 
-    // Palm devices need IoT vs Classic routing; LightSwitch always uses
-    // single_press_type to decide. Both branches converge on the same
-    // two backend calls.
-    const isPalm = this.product_model === CommonModels.Palm;
-    const prefersIot = isPalm
-      ? this.single_press_type == SinglePressType.IOT || this.switch_iot !== undefined
-      : this.single_press_type == SinglePressType.IOT;
+    const prefersIot = this.single_press_type == SinglePressType.IOT;
 
     const call = prefersIot
       ? this.plugin.client.wallSwitchIot(this.mac, this.product_model, !!value)

--- a/src/accessories/WyzeTemperatureHumidity.js
+++ b/src/accessories/WyzeTemperatureHumidity.js
@@ -87,6 +87,7 @@ module.exports = class WyzeTemperatureHumidity extends WyzeAccessory {
         );
       return;
     }
+    if (!device.device_params) return;
 
     const tempC = this.plugin.client.wyzeTemperatureToHomeKit(device.device_params.th_sensor_temperature);
     const humidityPct = device.device_params.th_sensor_humidity;

--- a/src/accessories/WyzeThermostat.js
+++ b/src/accessories/WyzeThermostat.js
@@ -3,7 +3,6 @@ const WyzeAccessory = require("./WyzeAccessory");
 const { markServiceOnline } = require("./offlineIndicator");
 
 // Future ideas:
-//   - Fan mode switch (auto / circ / on)
 //   - Per-room temp sensors (see WyzeRoomSensor)
 //   - "Time-to-temperature" estimate as a custom characteristic
 
@@ -28,8 +27,44 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
     this.thermostatWorkingState = persisted.thermostatWorkingState ?? "idle";
     this.thermostatTempUnit = persisted.thermostatTempUnit ?? "F";
     this.thermostatHumidity = persisted.thermostatHumidity ?? 50;
+    this.thermostatFanMode = persisted.thermostatFanMode ?? "auto";
+    this.thermostatEmheat = persisted.thermostatEmheat ?? false;
+    this.thermostatCurrentScenario = persisted.thermostatCurrentScenario ?? "none";
+    this.thermostatHold = persisted.thermostatHold ?? false;
+    this.thermostatKidLock = persisted.thermostatKidLock ?? false;
 
     this.service = this.getThermostatService();
+
+    this.fanService = this.getOrAddSwitchService("fan", "Fan");
+    this.fanService
+      .getCharacteristic(Characteristic.On)
+      .onGet(this.handleFanGet.bind(this))
+      .onSet(this.handleFanSet.bind(this));
+
+    // Scenario is read-only — reflects active schedule, snaps back on set.
+    this.scenarioService = this.getOrAddSwitchService("scenario", "Scenario");
+    this.scenarioService
+      .getCharacteristic(Characteristic.On)
+      .onGet(this.handleScenarioGet.bind(this))
+      .onSet(this.handleScenarioSet.bind(this));
+
+    this.emheatService = this.getOrAddSwitchService("emheat", "Emergency Heat");
+    this.emheatService
+      .getCharacteristic(Characteristic.On)
+      .onGet(this.handleEmheatGet.bind(this))
+      .onSet(this.handleEmheatSet.bind(this));
+
+    this.holdService = this.getOrAddSwitchService("hold", "Hold");
+    this.holdService
+      .getCharacteristic(Characteristic.On)
+      .onGet(this.handleHoldGet.bind(this))
+      .onSet(this.handleHoldSet.bind(this));
+
+    this.kidLockService = this.getOrAddSwitchService("kidlock", "Keypad Lock");
+    this.kidLockService
+      .getCharacteristic(Characteristic.On)
+      .onGet(this.handleKidLockGet.bind(this))
+      .onSet(this.handleKidLockSet.bind(this));
 
     this.service
       .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
@@ -93,6 +128,16 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
     return service;
   }
 
+  getOrAddSwitchService(subtype, displayName) {
+    let service = this.homeKitAccessory.getServiceById(Service.Switch, subtype);
+    if (!service) {
+      if (this.plugin.config.pluginLoggingEnabled)
+        this.plugin.log(`[Thermostat] [${displayName}] Adding service for "${this.display_name}"`);
+      service = this.homeKitAccessory.addService(Service.Switch, displayName, subtype);
+    }
+    return service;
+  }
+
   // ---- Get handlers ---------------------------------------------------------
 
   async handleCurrentTemperatureGet() {
@@ -125,6 +170,26 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
 
   async handleTemperatureDisplayUnitsGet() {
     return this.plugin.client.wyzeTempUnitToHomeKit(this.thermostatTempUnit);
+  }
+
+  async handleFanGet() {
+    return this.thermostatFanMode !== "auto";
+  }
+
+  async handleEmheatGet() {
+    return this.thermostatEmheat;
+  }
+
+  async handleScenarioGet() {
+    return this.thermostatCurrentScenario !== "none";
+  }
+
+  async handleHoldGet() {
+    return this.thermostatHold;
+  }
+
+  async handleKidLockGet() {
+    return this.thermostatKidLock;
   }
 
   // ---- Set handlers ---------------------------------------------------------
@@ -202,6 +267,66 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
     this.service.getCharacteristic(Characteristic.TemperatureDisplayUnits).updateValue(value);
   }
 
+  async handleFanSet(value) {
+    const newFanMode = value ? "on" : "auto";
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(`[Thermostat] Set fan mode "${this.display_name}": ${newFanMode}`);
+    try {
+      await this.setFanMode(newFanMode);
+      this.thermostatFanMode = newFanMode;
+      this.fanService.getCharacteristic(Characteristic.On).updateValue(value);
+    } catch (err) {
+      this.plugin.log.error(`[Thermostat] setFanMode failed: ${err.message || err}`);
+      throw err;
+    }
+  }
+
+  async handleEmheatSet(value) {
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(`[Thermostat] Set emergency heat "${this.display_name}": ${value}`);
+    try {
+      await this.plugin.client.thermostatSetIotProp(this.mac, this.product_model, "emheat", value ? 1 : 0);
+      this.thermostatEmheat = value;
+      this.emheatService.getCharacteristic(Characteristic.On).updateValue(value);
+    } catch (err) {
+      this.plugin.log.error(`[Thermostat] setEmheat failed: ${err.message || err}`);
+      throw err;
+    }
+  }
+
+  async handleScenarioSet() {
+    // Scenario is read-only — snap back to reflect actual device state.
+    this.scenarioService
+      .getCharacteristic(Characteristic.On)
+      .updateValue(this.thermostatCurrentScenario !== "none");
+  }
+
+  async handleHoldSet(value) {
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(`[Thermostat] Set hold "${this.display_name}": ${value}`);
+    try {
+      await this.plugin.client.thermostatSetIotProp(this.mac, this.product_model, "dev_hold", value ? 1 : 0);
+      this.thermostatHold = value;
+      this.holdService.getCharacteristic(Characteristic.On).updateValue(value);
+    } catch (err) {
+      this.plugin.log.error(`[Thermostat] setHold failed: ${err.message || err}`);
+      throw err;
+    }
+  }
+
+  async handleKidLockSet(value) {
+    if (this.plugin.config.pluginLoggingEnabled)
+      this.plugin.log(`[Thermostat] Set keypad lock "${this.display_name}": ${value}`);
+    try {
+      await this.plugin.client.thermostatSetIotProp(this.mac, this.product_model, "kid_lock", value ? 1 : 0);
+      this.thermostatKidLock = value;
+      this.kidLockService.getCharacteristic(Characteristic.On).updateValue(value);
+    } catch (err) {
+      this.plugin.log.error(`[Thermostat] setKidLock failed: ${err.message || err}`);
+      throw err;
+    }
+  }
+
   // ---- Update cycle ---------------------------------------------------------
 
   async updateCharacteristics(device) {
@@ -246,6 +371,12 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
         case "temp_unit":     this.thermostatTempUnit = value; break;
         case "mode_sys":      this.thermostatModeSys = value; break;
         case "humidity":      this.thermostatHumidity = Math.round(value); break;
+        case "fan_mode":      this.thermostatFanMode = value; break;
+        case "emheat":        this.thermostatEmheat = value; break;
+        case "current_scenario": this.thermostatCurrentScenario = value; break;
+        case "dev_hold":      this.thermostatHold = value; break;
+        case "kid_lock":      this.thermostatKidLock = value; break;
+        // can check for "iot_state" and "time2temp_val" in future if needed
       }
     }
     if (response?.ts) this.lastTimestamp = response.ts;
@@ -275,6 +406,21 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
     this.service
       .getCharacteristic(Characteristic.HeatingThresholdTemperature)
       .updateValue(c.fahrenheitToCelsius(this.thermostatHeatSetpoint));
+    this.fanService
+      .getCharacteristic(Characteristic.On)
+      .updateValue(this.thermostatFanMode !== "auto");
+    this.emheatService
+      .getCharacteristic(Characteristic.On)
+      .updateValue(this.thermostatEmheat);
+    this.scenarioService
+      .getCharacteristic(Characteristic.On)
+      .updateValue(this.thermostatCurrentScenario !== "none");
+    this.holdService
+      .getCharacteristic(Characteristic.On)
+      .updateValue(this.thermostatHold);
+    this.kidLockService
+      .getCharacteristic(Characteristic.On)
+      .updateValue(this.thermostatKidLock);
 
     // Persist so the next reboot has real values immediately instead of
     // the hardcoded constructor defaults.
@@ -286,6 +432,11 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
       thermostatWorkingState: this.thermostatWorkingState,
       thermostatTempUnit: this.thermostatTempUnit,
       thermostatHumidity: this.thermostatHumidity,
+      thermostatFanMode: this.thermostatFanMode,
+      thermostatEmheat: this.thermostatEmheat,
+      thermostatCurrentScenario: this.thermostatCurrentScenario,
+      thermostatHold: this.thermostatHold,
+      thermostatKidLock: this.thermostatKidLock,
     });
 
     if (this.plugin.config.pluginLoggingEnabled)
@@ -315,6 +466,7 @@ module.exports = class WyzeThermostat extends WyzeAccessory {
   async setPreset(value) {
     return this.plugin.client.thermostatSetIotProp(this.mac, this.product_model, "config_scenario", value);
   }
+
   async setFanMode(value) {
     // Wyze accepts: 'auto', 'circ', 'on'
     return this.plugin.client.thermostatSetIotProp(this.mac, this.product_model, "fan_mode", value);

--- a/src/enums.js
+++ b/src/enums.js
@@ -136,3 +136,55 @@ exports.ThermostatRoomSensor = ThermostatRoomSensor
 exports.VacuumModels = VacuumModels
 exports.IrrigationModels = IrrigationModels
 exports.applyConfigOverrides = applyConfigOverrides
+
+// Friendly display names for log lines. Not exhaustive — falls back to the
+// raw product_model code for anything not listed here.
+const ModelNames = {
+  // Locks
+  "DX_LB2":          "Lock Bolt V2",
+  "DX_PVLOC":        "Palm Lock",
+  "YD.LO1":          "Lock",
+  // Plugs
+  "WLPP1":           "Plug",
+  "WLPP1CFH":        "Plug",
+  "WLPPO-SUB":       "Outdoor Plug (satellite)",
+  // Lights
+  "WLPA19":          "Bulb White",
+  "HL_HWB2":         "Bulb White V2",
+  "WLPA19C":         "Color Bulb",
+  "HL_BR30C":        "BR30 Color Bulb",
+  "HL_A19C2":        "A19 Color Bulb V2",
+  "HL_LSL":          "Light Strip",
+  "HL_LSLP":         "Light Strip Pro",
+  // Sensors
+  "DWS2U":           "Contact Sensor V1",
+  "DWS3U":           "Contact Sensor V2",
+  "PIR2U":           "Motion Sensor V1",
+  "PIR3U":           "Motion Sensor V2",
+  "WS3U":            "Leak Sensor",
+  // Cameras
+  "WYZEC1":          "Cam V1",
+  "WYZEC1-JZ":       "Cam V2",
+  "WYZE_CAKP2JFUS":  "Cam V3",
+  "HL_CAM3P":        "Cam V3 Pro",
+  "HL_CAM4":         "Cam V4",
+  "WYZECP1_JEF":     "Cam Pan",
+  "HL_PAN2":         "Cam Pan V2",
+  "HL_PAN3":         "Cam Pan V3",
+  "WVOD1":           "Cam Outdoor",
+  "HL_WCO2":         "Cam Outdoor V2",
+  "AN_RSCW":         "Battery Cam Pro",
+  "LD_CFP":          "Cam Floodlight Pro",
+  "GW_GC1":          "Cam OG",
+  "GW_GC":           "Cam OG Telephoto 3x",
+  // Vacuum / Irrigation
+  "JA_RO2":          "Robot Vacuum",
+  "BS_WK1":          "Sprinkler Controller",
+  // Other
+  "TH3U":            "Temp/Humidity Sensor",
+  "CO_EA1":          "Thermostat",
+  "CO_TH1":          "Thermostat Room Sensor",
+  "GW3U":            "S1 Gateway",
+  "LD_SS1":          "Light Switch",
+}
+exports.ModelNames = ModelNames


### PR DESCRIPTION
Reopened as a clean 2-commit history (reconciliation + version bump) — closed #313 to redo it this way instead of carrying all 32 of main's individual historical commits forward.

## Summary

`main` (0.5.x) has picked up 24 commits of real stability/UX work since the branches last synced at `412b891` (2026-04-23) — optimistic non-blocking setters with command grace periods, log-noise reduction, several code-review bug fixes — none of which made it onto `2.0.0`. This merges that work forward.

This is a manual reconciliation across 18 conflicting files, not a mechanical merge. `main` and `2.0.0` had independently built *overlapping* features in that time — most notably two separate LockBoltV2/Palm Lock implementations (both via IoT3) and two separate Thermostat fan/emheat/hold/kidlock implementations — so several files needed combining both sides rather than picking one. Full breakdown in the CHANGELOG entry this PR adds.

## What's included

- **Optimistic non-blocking setters + command grace periods** ported to `WyzePlug`, `WyzeLight`, `WyzeMeshLight`, `WyzeSwitch`, `WyzeHMS`, `WyzeLock`, and `WyzeLockBoltV2` — previously only locks had this on `2.0.0`. Differentiated 15s lock / 90s unlock grace window.
- `WyzeLockBoltV2` gained `main`'s `ChargingState`/firmware-version reporting and fast IoT3 offline detection, layered onto `2.0.0`'s persistence/`StatusFault` architecture (kept as the base since it already has more infrastructure).
- `WyzeThermostat` gained `main`'s fan mode / emergency heat / hold / keypad-lock / scenario switches, rewritten against `2.0.0`'s delegated `wyze-api` conversion helpers instead of `main`'s local helpers (which don't exist in this branch's structure).
- `ModelNames` lookup table + standardized log prefixes across all accessories.
- Log-noise reduction + an accessory-routing fix from `main` — verified `2.0.0`'s dispatch logic (`getAccessoryClass`) was already structurally immune to the specific bug this fixed (explicit `break` per case, unlike `main`'s pre-fix fallthrough-prone version), so no functional change was needed there, just confirmed.
- Several null-guard / bug fixes from `main`'s code-review passes.
- Bumped to `v2.0.0-beta.2`.

## Not included (separate PRs to follow)

This PR intentionally does **not** touch the `src/wyze-api` submodule pointer, `configSample.json`, or `README.md` — those, plus several follow-up fixes found while testing this merge (a Homebridge-2.x accessory-persistence bug with cameras, a camera-control routing gap for newer DeviceMgmt-era models, and a couple of security-audit findings), are queued as smaller follow-up PRs once this one's reviewed.

## Test plan

- [x] `node --check` on every touched file
- [x] `require()` smoke test on every accessory file, `WyzeSmartHome.js`, `enums.js` — all load without error
- [x] Ran this against a real installed Homebridge 2.1.0 with a dummy-credentials config: plugin loads, platform registers, bridge starts and generates a pairing QR code, zero warnings/deprecation notices in the log
- [ ] Haven't been able to test optimistic-update/grace-period behavior against a real Wyze account — would appreciate a real-device smoke test from anyone able to run this branch

This is step 1 of a planned series of smaller PRs — see [jfarmer08/wyze-api#52](https://github.com/jfarmer08/wyze-api/pull/52) for the corresponding wyze-api PR this one's `src/wyze-api` submodule work will eventually build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)